### PR TITLE
Changes related to global/nest and regional configuration in ./parm/h…

### DIFF
--- a/parm/hafs_globnest_static.conf
+++ b/parm/hafs_globnest_static.conf
@@ -44,7 +44,7 @@ refine_ratio=4       ;; Specify the refinement ratio for nest grid
 istart_nest=45
 jstart_nest=237
 iend_nest=1484
-jend_nest=1286
+jend_nest=1196
 
 [forecast]
 # For the global domain if it is a global or global-nesting experiment
@@ -62,10 +62,10 @@ npz=64
 output_grid='rotated_latlon'
 output_grid_cen_lon=-62.0         ;; central longitude
 output_grid_cen_lat=25.0          ;; central latitude
-output_grid_lon1=-40.5            ;; longitude of lower-left point in rotated coordinate system (in degrees)
-output_grid_lat1=-22.0            ;; latitude of lower-left . . . .
-output_grid_lon2=40.5             ;; longitude of upper-right . . . .
-output_grid_lat2=22.0             ;; latitude of upper-right . . . .
+output_grid_lon1=-35.0            ;; longitude of lower-left point in rotated coordinate system (in degrees)
+output_grid_lat1=-24.0            ;; latitude of lower-left . . . .
+output_grid_lon2=35.0             ;; longitude of upper-right . . . .
+output_grid_lat2=24.0             ;; latitude of upper-right . . . .
 output_grid_dlon=0.025            ;; output grid spacing dlon . . . .
 output_grid_dlat=0.025            ;; output grid spacing dlat . . . .
 

--- a/parm/hafs_regional_static.conf
+++ b/parm/hafs_regional_static.conf
@@ -44,7 +44,7 @@ refine_ratio=4       ;; Specify the refinement ratio for nest grid
 istart_nest=46
 jstart_nest=238
 iend_nest=1485
-jend_nest=1287
+jend_nest=1197
 
 [forecast]
 layoutx=40

--- a/rocoto/sites/xjet.ent
+++ b/rocoto/sites/xjet.ent
@@ -18,7 +18,7 @@
   <!ENTITY REQUEST_THREADS "<envar><name>PURE_OPENMP_THREADS</name><value>&THREADS;</value></envar><envar><name>OMP_NUM_THREADS</name><value>&THREADS;</value></envar><envar><name>KMP_NUM_THREADS</name><value>&THREADS;</value></envar>">
 
   <!ENTITY GRID_RESOURCES "<cores>24</cores><envar><name>TOTAL_TASKS</name><value>4</value></envar><envar><name>OMP_THREADS</name><value>6</value></envar><walltime>00:30:00</walltime>">
-  <!ENTITY CHGRES_IC_RESOURCES "<nodes>1:ppn=1:tpp=24</nodes><envar><name>TOTAL_TASKS</name><value>1</value></envar><envar><name>OMP_THREADS</name><value>24</value></envar><walltime>00:30:00</walltime>">
+  <!ENTITY CHGRES_IC_RESOURCES "<nodes>1:ppn=24:tpp=24</nodes><envar><name>TOTAL_TASKS</name><value>1</value></envar><envar><name>OMP_THREADS</name><value>24</value></envar><walltime>00:30:00</walltime>">
   <!ENTITY CHGRES_BC_RESOURCES "<nodes>21:ppn=1:tpp=1</nodes><envar><name>TOTAL_TASKS</name><value>21</value></envar><envar><name>OMP_THREADS</name><value>24</value></envar><walltime>00:30:00</walltime>">
 
   <!ENTITY FORECAST_WALLTIME "<walltime>06:00:00</walltime>">


### PR DESCRIPTION
1. change jend_nest to 1196 (original 1286) to be consistent with grid job setting;
2. reduce output_grid domain dimension (with quilting=true) in order for forecast not to fail;
3. change xjet entity file for chgres_ic to be run. (ppn=1 changed to ppn=24)