### PR TITLE
Added option to deliver track file to noscrub directory when 00L is run

### DIFF
--- a/scripts/exhafs_product.sh
+++ b/scripts/exhafs_product.sh
@@ -132,12 +132,27 @@ ${APRUNC} ./gettrk.x < namelist.gettrk
 # Extract the tracking records for tmpvit
 STORMNUM=$(echo ${STORMID} | cut -c1-2)
 STORMBS1=$(echo ${STORMID} | cut -c3)
+cp ${COMhafs}/${all_atcfunix} ${COMhafs}/${all_atcfunix}.orig
+if [ $STORMNUM == "00" ] ; then
+norig=`cat ${COMhafs}/${all_atcfunix}.orig |wc -l `
+if [ $norig -eq 1 ] ; then
+> ${COMhafs}/${all_atcfunix}
+else
+grep -v "^.., ${STORMNUM}," ${COMhafs}/${all_atcfunix}.orig >  ${COMhafs}/${all_atcfunix}
+fi
+else
 grep "^.., ${STORMNUM}," ${COMhafs}/${all_atcfunix} | grep -E "^${STORMBS1}.,|^.${STORMBS1}," > ${COMhafs}/${trk_atcfunix}
+fi
 
 # Deliver track file to NOSCRUB:
 mkdir -p ${CDNOSCRUB}/${SUBEXPT}
+cp -p ${COMhafs}/${all_atcfunix}.orig ${CDNOSCRUB}/${SUBEXPT}/.
+if [ -s ${COMhafs}/${all_atcfunix} ] ; then 
 cp -p ${COMhafs}/${all_atcfunix} ${CDNOSCRUB}/${SUBEXPT}/.
+fi
+if [ -s ${COMhafs}/${trk_atcfunix} ] && [ $STORMNUM != "00" ] ; then 
 cp -p ${COMhafs}/${trk_atcfunix} ${CDNOSCRUB}/${SUBEXPT}/.
+fi
 #===============================================================================
 
 cd ${DATA}


### PR DESCRIPTION
Changes include:
1. Always deliver ${all_atcfunix}.orig file
2. if run 00L, remove 00L item from ${all_atcfunix}.orig, and create a new track file: ${all_atcfunix},
if ${all_atcfunix} is empty, no delivery, otherwise, deliver ${all_atcfunix}  to noscrub directory
3. if storm-focus,say 09L, will deliver following atcf files: ${all_atcfunix}.orig (original atcf),  ${all_atcfunix}: contains all storms in the domain, and ${trk_atcfunix}: contains specific storm track forecasts