### PR TITLE
Update to use newer version g2 library under hpc-stack

### DIFF
--- a/modulefiles/modulefile.hafs.hera
+++ b/modulefiles/modulefile.hafs.hera
@@ -33,7 +33,6 @@ module load fms/2020.04.03
 
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.2
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
@@ -46,8 +45,7 @@ module load gftl-shared/v1.3.0
 module load yafyaml/v0.5.1
 module load mapl/v2.7.3
 
-# a temporary workaround, since hafs_gfs2ofs2.x needs g2/3.4.1.
-module load g2/3.4.1
+module load g2/3.4.3
 
 module load bufr/11.4.0
 module load gfsio/1.4.1

--- a/modulefiles/modulefile.hafs.jet
+++ b/modulefiles/modulefile.hafs.jet
@@ -33,7 +33,6 @@ module load fms/2020.04.03
 
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.2
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
@@ -46,8 +45,7 @@ module load gftl-shared/v1.3.0
 module load yafyaml/v0.5.1
 module load mapl/v2.7.3
 
-# a temporary workaround, since hafs_gfs2ofs2.x needs g2/3.4.1.
-module load g2/3.4.1
+module load g2/3.4.3
 
 module load bufr/11.4.0
 module load gfsio/1.4.1

--- a/modulefiles/modulefile.hafs.orion
+++ b/modulefiles/modulefile.hafs.orion
@@ -31,7 +31,6 @@ module load fms/2020.04.03
 
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.2
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
@@ -44,8 +43,7 @@ module load gftl-shared/v1.3.0
 module load yafyaml/v0.5.1
 module load mapl/v2.7.3
 
-# a temporary workaround, since hafs_gfs2ofs2.x needs g2/3.4.1.
-module load g2/3.4.1
+module load g2/3.4.3
 
 module load bufr/11.4.0
 module load gfsio/1.4.1

--- a/modulefiles/modulefile.hafs.wcoss_cray
+++ b/modulefiles/modulefile.hafs.wcoss_cray
@@ -35,7 +35,6 @@ module use /usrx/local/nceplibs/NCEPLIBS/cmake/install/NCEPLIBS-v1.3.0/modules
 module load pio/2.5.2
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.1
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
@@ -44,8 +43,7 @@ module load w3emc/2.7.3
 module load w3nco/2.4.1
 module load upp/10.0.8
 
-# a temporary workaround, since hafs_gfs2ofs2.x needs g2/3.4.1.
-module load g2/3.4.1
+module load g2/3.4.3
 
 module load bufr/11.4.0
 module load gfsio/1.4.1

--- a/modulefiles/modulefile.hafs.wcoss_dell_p3
+++ b/modulefiles/modulefile.hafs.wcoss_dell_p3
@@ -30,7 +30,6 @@ module load fms/2020.04.03
 
 module load bacio/2.4.1
 module load crtm/2.3.0
-module load g2/3.4.2
 module load g2tmpl/1.10.0
 module load ip/3.3.3
 module load nemsio/2.5.2
@@ -43,8 +42,7 @@ module load gftl-shared/v1.3.0
 module load yafyaml/v0.5.1
 module load mapl/v2.7.3
 
-# a temporary workaround, since hafs_gfs2ofs2.x needs g2/3.4.1. 
-module load g2/3.4.1
+module load g2/3.4.3
 
 module load bufr/11.4.0
 module load gfsio/1.4.1

--- a/sorc/build_vortextracker.sh
+++ b/sorc/build_vortextracker.sh
@@ -11,32 +11,22 @@ if [ $target = hera ]; then
   export FC=ifort
   export F90=ifort
   export CC=icc
-  export hwrf_g2_inc=/scratch1/NCEPDEV/hwrf/save/Bin.Liu/hwrf-utilities/libs/mods/g2
-  export hwrf_g2_lib=/scratch1/NCEPDEV/hwrf/save/Bin.Liu/hwrf-utilities/libs/libg2.a
 elif [ $target = orion ]; then
   export FC=ifort
   export F90=ifort
   export CC=icc
-  export hwrf_g2_inc=/work/noaa/hwrf/noscrub/bthomas/H220/sorc/hwrf-utilities/libs/mods/g2
-  export hwrf_g2_lib=/work/noaa/hwrf/noscrub/bthomas/H220/sorc/hwrf-utilities/libs/libg2.a
 elif [ $target = jet ]; then
   export FC=ifort
   export F90=ifort
   export CC=icc
-  export hwrf_g2_inc=/lfs4/HFIP/hwrf-vd/Zhan.Zhang/H219_kjet/sorc/hwrf-utilities/libs/mods/g2
-  export hwrf_g2_lib=/lfs4/HFIP/hwrf-vd/Zhan.Zhang/H219_kjet/sorc/hwrf-utilities/libs/libg2.a
 elif [ $target = wcoss_cray ]; then
   export FC=ftn
   export F90=ftn
   export CC=icc
-  export hwrf_g2_inc=/gpfs/hps3/emc/hwrf/noscrub/Bin.Liu/save/H221final/sorc/hwrf-utilities/libs/mods/g2
-  export hwrf_g2_lib=/gpfs/hps3/emc/hwrf/noscrub/Bin.Liu/save/H221final/sorc/hwrf-utilities/libs/libg2.a
 elif [ $target = wcoss_dell_p3 ]; then
   export FC=ifort
   export F90=ifort
   export CC=icc
-  export hwrf_g2_inc=/gpfs/dell2/emc/modeling/noscrub/Biju.Thomas/save/trunk_20210420/sorc/hwrf-utilities/libs/mods/g2
-  export hwrf_g2_lib=/gpfs/dell2/emc/modeling/noscrub/Biju.Thomas/save/trunk_20210420/sorc/hwrf-utilities/libs/libg2.a
 else
   echo "Unknown machine = $target"
   exit 1
@@ -48,16 +38,9 @@ if [ -d "build" ]; then
 fi
 mkdir build
 cd build
-if [ $target = hera ]; then
-  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -Dhwrf_g2_lib=$hwrf_g2_lib -Dhwrf_g2_inc=$hwrf_g2_inc
-elif [ $target = orion ]; then
-  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -Dhwrf_g2_lib=$hwrf_g2_lib -Dhwrf_g2_inc=$hwrf_g2_inc
-elif [ $target = jet ]; then
-  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -Dhwrf_g2_lib=$hwrf_g2_lib -Dhwrf_g2_inc=$hwrf_g2_inc
-elif [ $target = wcoss_cray ]; then
-  cmake .. -DCMAKE_Fortran_COMPILER=ftn -DCMAKE_C_COMPILER=cc -Dhwrf_g2_lib=$hwrf_g2_lib -Dhwrf_g2_inc=$hwrf_g2_inc
-elif [ $target = wcoss_dell_p3 ]; then
-  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc -Dhwrf_g2_lib=$hwrf_g2_lib -Dhwrf_g2_inc=$hwrf_g2_inc
+
+if [ $target = wcoss_cray ]; then
+  cmake .. -DCMAKE_Fortran_COMPILER=ftn -DCMAKE_C_COMPILER=cc
 else
   cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc
 fi


### PR DESCRIPTION
Due to two bugs [#63](https://github.com/NOAA-EMC/NCEPLIBS-g2/issues/63) in the g2 library(prior to the latest 3.4.3 version), hafs subcomponents (hycom_utils and vortextracker) fail with g2 from hpc-stack on certain platforms. Currently, the workaround is, use g2 from HWRF build in the vortextracker component, and point to the specific g2/3.4.1 version for hycom_utils build. The two bugs in g2 were fixed in the 3.4.3 release.  Accordingly, the HAFS script and modulefile files were updated to point g2/3.4.2 in the Head.

This PR addresses Issues #57 and #78.