### PR TITLE
Creating standalone CMake build system for hafs-community/gfdl-tracker

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = support/HAFS
 [submodule "gfdl-tracker"]
 	path = sorc/hafs_vortextracker.fd
-	url = https://github.com/hafs-community/gfdl-tracker.git
+    url = https://github.com/BijuThomas-NOAA/gfdl-tracker.git
 	branch = support/HAFS
 [submodule "NCEPLIBS-pyprodutil"]
 	path = ush/produtil_repo

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = support/HAFS
 [submodule "gfdl-tracker"]
 	path = sorc/hafs_vortextracker.fd
-        url = https://github.com/hafs-community/gfdl-tracker.git
+       url = https://github.com/hafs-community/gfdl-tracker.git
 	branch = support/HAFS
 [submodule "NCEPLIBS-pyprodutil"]
 	path = ush/produtil_repo

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = support/HAFS
 [submodule "gfdl-tracker"]
 	path = sorc/hafs_vortextracker.fd
-    url = https://github.com/BijuThomas-NOAA/gfdl-tracker.git
+        url = https://github.com/hafs-community/gfdl-tracker.git
 	branch = support/HAFS
 [submodule "NCEPLIBS-pyprodutil"]
 	path = ush/produtil_repo

--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,7 @@
 	branch = support/HAFS
 [submodule "gfdl-tracker"]
 	path = sorc/hafs_vortextracker.fd
-       url = https://github.com/hafs-community/gfdl-tracker.git
+	url = https://github.com/hafs-community/gfdl-tracker.git
 	branch = support/HAFS
 [submodule "NCEPLIBS-pyprodutil"]
 	path = ush/produtil_repo

--- a/sorc/build_vortextracker.sh
+++ b/sorc/build_vortextracker.sh
@@ -1,52 +1,7 @@
 #!/bin/sh
 set -eux
-source ./machine-setup.sh > /dev/null 2>&1
-cwd=`pwd`
 
-module use ../modulefiles
-module load modulefile.hafs.$target
-module list
-
-if [ $target = hera ]; then
-  export FC=ifort
-  export F90=ifort
-  export CC=icc
-elif [ $target = orion ]; then
-  export FC=ifort
-  export F90=ifort
-  export CC=icc
-elif [ $target = jet ]; then
-  export FC=ifort
-  export F90=ifort
-  export CC=icc
-elif [ $target = wcoss_cray ]; then
-  export FC=ftn
-  export F90=ftn
-  export CC=icc
-elif [ $target = wcoss_dell_p3 ]; then
-  export FC=ifort
-  export F90=ifort
-  export CC=icc
-else
-  echo "Unknown machine = $target"
-  exit 1
-fi
-
-cd hafs_vortextracker.fd
-if [ -d "build" ]; then
-   rm -rf build
-fi
-mkdir build
-cd build
-
-if [ $target = wcoss_cray ]; then
-  cmake .. -DCMAKE_Fortran_COMPILER=ftn -DCMAKE_C_COMPILER=cc
-else
-  cmake .. -DCMAKE_Fortran_COMPILER=ifort -DCMAKE_C_COMPILER=icc
-fi
-make -j 8 VERBOSE=1
-make install
-
-cd ../
+cd hafs_vortextracker.fd/ush
+./build_all_cmake.sh
 
 exit

--- a/sorc/build_vortextracker.sh
+++ b/sorc/build_vortextracker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eux
 
-cd hafs_vortextracker.fd/ush
+cd hafs_vortextracker.fd/src
 ./build_all_cmake.sh
 
 exit


### PR DESCRIPTION
## Description
The changes in this merge will enable the vortextracker component to be built in a standalone mode with CMake and it can be easily transitioned vortextracker component to other systems outside HAFS. 

## Dependencies
- Dependent on: hafs-community/gfdl-tracker/pull/1
- Dependent on: hafs-community/gfdl-tracker/pull/2