### PR TITLE
Feature/add fms2 io nml fieldtable

### DIFF
--- a/parm/forecast/globnest/field_table
+++ b/parm/forecast/globnest/field_table
@@ -34,10 +34,9 @@
  "TRACER", "atmos_mod", "sgs_tke"
            "longname",     "subgrid scale turbulent kinetic energy"
            "units",        "m2/s2"
-       "profile_type", "fixed", "surface_value=1.e30" /
+       "profile_type", "fixed", "surface_value=0.0" /
 # non-prognostic cloud amount
  "TRACER", "atmos_mod", "cld_amt"
            "longname",     "cloud amount"
            "units",        "1"
-       "profile_type", "fixed", "surface_value=1.e30" /
-
+       "profile_type", "fixed", "surface_value=0.0" /

--- a/parm/forecast/globnest/input.nml.tmp
+++ b/parm/forecast/globnest/input.nml.tmp
@@ -25,6 +25,10 @@
        max_files_w = 100,
 /
 
+ &fms2_io_nml
+netcdf_default_format="netcdf4"
+/
+
  &fms_nml
        clock_grain = 'ROUTINE',
        domains_stack_size = 30000000,

--- a/parm/forecast/globnest/input_nest02.nml.tmp
+++ b/parm/forecast/globnest/input_nest02.nml.tmp
@@ -25,6 +25,10 @@
        max_files_w = 100,
 /
 
+ &fms2_io_nml
+netcdf_default_format="netcdf4"
+/
+
  &fms_nml
        clock_grain = 'ROUTINE',
        domains_stack_size = 30000000,

--- a/parm/forecast/globnest_hwrf/input.nml.tmp
+++ b/parm/forecast/globnest_hwrf/input.nml.tmp
@@ -25,6 +25,10 @@
        max_files_w = 100,
 /
 
+ &fms2_io_nml
+netcdf_default_format="netcdf4"
+/
+
  &fms_nml
        clock_grain = 'ROUTINE',
        domains_stack_size = 30000000,

--- a/parm/forecast/globnest_hwrf/input_nest02.nml.tmp
+++ b/parm/forecast/globnest_hwrf/input_nest02.nml.tmp
@@ -25,6 +25,10 @@
        max_files_w = 100,
 /
 
+ &fms2_io_nml
+netcdf_default_format="netcdf4"
+/
+
  &fms_nml
        clock_grain = 'ROUTINE',
        domains_stack_size = 30000000,

--- a/parm/forecast/regional/field_table
+++ b/parm/forecast/regional/field_table
@@ -34,10 +34,9 @@
  "TRACER", "atmos_mod", "sgs_tke"
            "longname",     "subgrid scale turbulent kinetic energy"
            "units",        "m2/s2"
-       "profile_type", "fixed", "surface_value=1.e30" /
+       "profile_type", "fixed", "surface_value=0.0" /
 # non-prognostic cloud amount
  "TRACER", "atmos_mod", "cld_amt"
            "longname",     "cloud amount"
            "units",        "1"
-       "profile_type", "fixed", "surface_value=1.e30" /
-
+       "profile_type", "fixed", "surface_value=0.0" /

--- a/parm/forecast/regional/input.nml.tmp
+++ b/parm/forecast/regional/input.nml.tmp
@@ -25,6 +25,10 @@
        max_files_w = 100,
 /
 
+ &fms2_io_nml
+netcdf_default_format="netcdf4"
+/
+
  &fms_nml
        clock_grain = 'ROUTINE',
        domains_stack_size = 30000000,

--- a/parm/forecast/regional_hwrf/input.nml.tmp
+++ b/parm/forecast/regional_hwrf/input.nml.tmp
@@ -25,6 +25,10 @@
        max_files_w = 100,
 /
 
+ &fms2_io_nml
+netcdf_default_format="netcdf4"
+/
+
  &fms_nml
        clock_grain = 'ROUTINE',
        domains_stack_size = 30000000,


### PR DESCRIPTION
## Description of changes
Copied the field_table_hafs to regional and globnest to sync the same field_table as in ufs-weather-model HAFS RTs.
Not copying the field_table from the RT into the *_hwrf directories, because those field_tables are specific to the HWRF physics suite in HAFS, and that suite has a unique set of tracers.
Fixes Issue #112

Added the fms2_io_nml namelist section with netcdf_default_format of netcdf4 in input*.nml
Otherwise, the default was the NetCDF "64-bit offset" version, which has issues to support large files.
Fixes Issue #117

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes hafs-community/HAFS/issues/112
- fixes hafs-community/HAFS/issues/117


## Contributors (optional)
@BinLiu-NOAA 
@bensonr

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests, including relevant details about the configuration(s) (e.g., cold versus warm start, number of cycles, forecast length, whether data assimilation was performed, etc). What platform(s) were used for testing?

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [x] Jet
- [x] Hera
- [x] Orion
- [x] WCOSS Dell P3
- [x] WCOSS Cray
