### PR TITLE
Fix a typo bug when copying hafs_sfc_climo_gen.x in exhafs_atm_prep.sh.

### DIFF
--- a/scripts/exhafs_atm_prep.sh
+++ b/scripts/exhafs_atm_prep.sh
@@ -417,7 +417,7 @@ EOF
 more ./fort.41
 
 #APRUNC="srun --ntasks=6 --ntasks-per-node=6 --cpus-per-task=1"
-if [[ -e ./hafs_sfc_climo_gen.x ]]; then
+if [[ ! -e ./hafs_sfc_climo_gen.x ]]; then
   cp -p $SFCCLIMOEXEC ./hafs_sfc_climo_gen.x
 fi
 $APRUNC ./hafs_sfc_climo_gen.x
@@ -504,7 +504,7 @@ EOF
 more ./fort.41
 
 #APRUNC="srun --ntasks=6 --ntasks-per-node=6 --cpus-per-task=1"
-if [[ -e ./hafs_sfc_climo_gen.x ]]; then
+if [[ ! -e ./hafs_sfc_climo_gen.x ]]; then
   cp -p $SFCCLIMOEXEC ./hafs_sfc_climo_gen.x
 fi
 $APRUNC ./hafs_sfc_climo_gen.x


### PR DESCRIPTION
## Description of changes
Fix a typo bug when copying hafs_sfc_climo_gen.x in exhafs_atm_prep.sh.

## Issues addressed (optional)
- fixes hafs-community/HAFS/issues/133

## Tests conducted
Tested on wcoss_cray.

Note: Since this is just a typo bug fix, we probably do not need do regression tests for this. We will merge this PR after the code reviewers approve this PR.

