### PR TITLE
Add the DA/GSI capability of 4DEnVar with GDAS ensembles

### DIFF
--- a/parm/analysis/gsi/gsiparm.anl.tmp
+++ b/parm/analysis/gsi/gsiparm.anl.tmp
@@ -13,7 +13,7 @@
   use_pbl=.true.,use_compress=.false.,nsig_ext=12,gpstop=50.,
   use_gfs_nemsio=_USE_GFS_NEMSIO_,use_gfs_ncio=_USE_GFS_NCIO_,
   print_diag_pcg=.true.,l2rwthin=.false.,hurricane_radar=.true.,
-  use_gfs_ozone=.false.,
+  use_gfs_ozone=.false.,l4densvar=_L4DENSVAR_,nhr_obsbin=_NHR_OBSBIN_,
   lrun_subdirs=.true.,
   netcdf_diag=_NETCDF_DIAG_,binary_diag=_BINARY_DIAG_,
   newpc4pred=.true., adp_anglebc=.true., angord=4,

--- a/parm/hafs.conf
+++ b/parm/hafs.conf
@@ -411,6 +411,8 @@ s_ens_h=150               ;; homogeneous isotropic horizontal ensemble localizat
 s_ens_v=-0.5              ;; vertical localization scale
 online_satbias=no         ;; Should we recycle satbias data?
 l_both_fv3sar_gfs_ens=.false. ;; Whether or not use both gdas and regional ensembles in GSI EnVar analysis
+l4densvar=.false.         ;; whether or not do 4DEnvVar
+nhr_obsbin=-1             ;; length of observation bins, e.g., 3: ensembles at 3,6,9-h; 7:, ensembles at 3,4,5,6,7,8,9-h.
 
 [enkf]
 corrlength=500            ;; length for horizontal localization in km

--- a/parm/hafs_holdvars.conf
+++ b/parm/hafs_holdvars.conf
@@ -123,6 +123,8 @@ s_ens_h={gsi/s_ens_h}
 s_ens_v={gsi/s_ens_v}
 online_satbias={gsi/online_satbias}
 l_both_fv3sar_gfs_ens={gsi/l_both_fv3sar_gfs_ens}
+l4densvar={gsi/l4densvar}
+nhr_obsbin={gsi/nhr_obsbin}
 corrlength={enkf/corrlength}
 lnsigcutoff={enkf/lnsigcutoff}
 

--- a/parm/hafs_holdvars.txt
+++ b/parm/hafs_holdvars.txt
@@ -170,6 +170,8 @@ export s_ens_h={s_ens_h}
 export s_ens_v={s_ens_v}
 export online_satbias={online_satbias}
 export l_both_fv3sar_gfs_ens={l_both_fv3sar_gfs_ens}
+export l4densvar={l4densvar}
+export nhr_obsbin={nhr_obsbin}
 export corrlength={corrlength}
 export lnsigcutoff={lnsigcutoff}
 

--- a/scripts/exhafs_analysis.sh
+++ b/scripts/exhafs_analysis.sh
@@ -28,6 +28,8 @@ export online_satbias=${online_satbias:-no}
 export l_both_fv3sar_gfs_ens=${l_both_fv3sar_gfs_ens:-.false.}
 export n_ens_gfs=${n_ens_gfs:-80}
 export n_ens_fv3sar=${n_ens_fv3sar:-${ENS_SIZE:-20}}
+export l4densvar=${l4densvar:-.false.}
+export nhr_obsbin=${nhr_obsbin:--1}
 
 export GSI_D01=${GSI_D01:-NO}
 export GSI_D02=${GSI_D02:-NO}
@@ -208,7 +210,11 @@ if [ ${RUN_ENSDA} != "YES" ] || [ $l_both_fv3sar_gfs_ens = .true. ]; then
   mkdir -p ensemble_data
   ENKF_SUFFIX="s"
   GSUFFIX=${GSUFFIX:-.nemsio}
-  fhrs="06"
+  if [ ${l4densvar:-.false.} = ".true." ]; then
+    fhrs="03 06 09"
+  else
+    fhrs="06"
+  fi
   for fhh in $fhrs; do
   rm -f filelist${fhh}
   for mem in $(seq -f '%03g' 1 ${n_ens_gfs}); do
@@ -614,6 +620,8 @@ sed -e "s/_MITER_/${MITER:-2}/g" \
     -e "s/_L_BOTH_FV3SAR_GFS_ENS_/${l_both_fv3sar_gfs_ens:-.false.}/g" \
     -e "s/_NENS_GFS_/${n_ens_gfs:-80}/g" \
     -e "s/_NENS_FV3SAR_/${n_ens_fv3sar:-20}/g" \
+    -e "s/_L4DENSVAR_/${l4densvar:-.false.}/g" \
+    -e "s/_NHR_OBSBIN_/${nhr_obsbin:--1}/g" \
     gsiparm.anl.tmp > gsiparm.anl
 
 #-------------------------------------------------------------------


### PR DESCRIPTION
## Description of changes
Add the DA/GSI capability of 4DEnVar with GDAS ensembles.  

## Issues addressed (optional)
- fixes hafs-community/HAFS/issues/167

## Contributors (optional)
Mainly from Xu Lu from OU, @XL-OU; POC: Xuguang Wang, OU. A working session among @XL-OU, @BinLiu-NOAA, Jason Sippel (AOML/HRD), @yonghuiweng, and @lbi2018 implemented these changes in HAFS application/workflow. 

## Tests conducted
Two cycle technical testing succeeded on Orion. And @yonghuiweng conducted retrospective tests with this 4DEnVar capability on top of the HAFSv1 baseline configuration.

## Application-level regression test status
Since this will not change/impact any existing HAFS application/workflow level regression tests, application-level regression tests on different platforms are not needed for this PR.
