### PR TITLE
Bug fix for gsl orography generating for two global regression tests.

### DIFF
--- a/jobs/JHAFS_ANALYSIS
+++ b/jobs/JHAFS_ANALYSIS
@@ -19,6 +19,7 @@ export RUN_ENVIR=${RUN_ENVIR:-dev} # nco or dev
 if [ "${RUN_ENVIR^^}" != NCO ]; then
   module use $HOMEhafs/sorc/hafs_gsi.fd/modulefiles
   if [ ${machine}  = "hera" ]; then
+    module purge
     module load gsi_${machine}.intel
   else
     module load gsi_${machine}

--- a/jobs/JHAFS_ANALYSIS
+++ b/jobs/JHAFS_ANALYSIS
@@ -19,7 +19,6 @@ export RUN_ENVIR=${RUN_ENVIR:-dev} # nco or dev
 if [ "${RUN_ENVIR^^}" != NCO ]; then
   module use $HOMEhafs/sorc/hafs_gsi.fd/modulefiles
   if [ ${machine}  = "hera" ]; then
-    module purge
     module load gsi_${machine}.intel
   else
     module load gsi_${machine}

--- a/scripts/exhafs_atm_prep.sh
+++ b/scripts/exhafs_atm_prep.sh
@@ -252,7 +252,7 @@ elif [ $gtype = nest ]; then
   # $APRUNCFP  -n $ncmd_max cfp $DATA/orog_gsl.file1
     $DATA/orog_gsl.file1
   else
-    ${APRUNF} $DATA/orog.file1
+    ${APRUNF} $DATA/orog_gsl.file1
   fi
   wait
   #rm $DATA/orog_gsl.file1


### PR DESCRIPTION

## Description of changes
1) Add "module purge" in jobs/JHAFS_ANALYSIS for Hera to avoid the "mkl" related error message on Hera. 
2) Change orog.file1 to orog_gsl.file1 in line 255 of scripts/exhafs_atm_prep.sh for the gsl orography.


## Issues addressed (optional)
N/A
## Dependencies (optional)
N/A

## Tests conducted
Tested on Hera

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [x] Hera
- [ ] Orion
- [ ] WCOSS2
