### PR TITLE
Fix code structure and logic in HAFS forecast J-Job, ex-script, and include for EE2 review

### DIFF
--- a/jobs/JHAFS_FORECAST
+++ b/jobs/JHAFS_FORECAST
@@ -4,68 +4,55 @@ date
 export PS4='+ $SECONDS + '
 set -xue
 
-export HOMEhafs=${HOMEhafs:?}
-export USHhafs=${USHhafs:-${HOMEhafs}/ush}
-export EXEChafs=${EXEChafs:-${HOMEhafs}/exec}
-export PARMhafs=${PARMhafs:-${HOMEhafs}/parm}
-export FIXhafs=${FIXhafs:-${HOMEhafs}/fix}
-
+#############################
+# Source shell init, module, and platform 
+#############################
 source ${USHhafs}/hafs_pre_job.sh.inc
+module list
+
+#############################
+# Source relevant config files
+#   NET, RUN, RUN_GSI, HOMEhafs, WORKhafs, DATA, COM, DATMdir, DOCNdir, STORMID, CASE, ETC.
+#############################
 source ${HOLDVARS:-storm1.holdvars.txt}
 
-export machine=${WHERE_AM_I:-wcoss2}
-export envir=${envir:-prod} # prod, para, test
-export RUN_ENVIR=${RUN_ENVIR:-dev} # nco or dev
-if [ "${RUN_ENVIR^^}" != NCO ]; then
- #module list
- #module unload intelpython
- #module use ${HOMEhafs}/sorc/hafs_forecast.fd/modulefiles
-  module list
-fi
-
+#############################
+# Source APRUN, job card info
+#############################
 source ${USHhafs}/hafs_runcmd.sh.inc
 
-# Run setpdy and initialize PDY variables
-#setpdy.sh
-#. ./PDY
-export PDY=${PDY:-$(echo ${YMDH} | cut -c 1-8 )}
-
-export WORKhafs=${WORKhafs:?}
-export COMIN=${COMIN:?}
-export COMOUT=${COMOUT:?}
-export COMhafs=${COMhafs:-${COMOUT}}
-export FIXcrtm=${FIXcrtm:-${CRTM_FIX:?}}
-
-export CDATE=${CDATE:-${YMDH}}
-export cyc=${cyc:?}
-export STORM=${STORM:-FAKE}
-export STORMID=${STORMID:-00L}
-export ENSDA=${ENSDA:-NO}
-
+#############################
 # Deterministic or ensemble
+#############################
 if [ "${ENSDA}" != YES ]; then
-  export FIXgrid=${FIXgrid:-${WORKhafs}/intercom/grid}
-  export INPdir=${INPdir:-${WORKhafs}/intercom/chgres}
   export DATA=${WORKhafs}/forecast
 else
   export ENSID=${ENSID:-001}
-  export FIXgrid=${FIXgrid:-${WORKhafs}/intercom/grid_ens}
-  export INPdir=${INPdir:-${WORKhafs}/intercom/chgres_ens/mem${ENSID}}
   export DATA=${WORKhafs}/forecast_ens/mem${ENSID}
 fi
 
+#############################
+# Init DATA location
+#############################
 export SCRUBDATA=${SCRUBDATA:-YES}
 if [ "${SCRUBDATA}" = YES ]; then
   rm -rf $DATA
 fi
-
 mkdir -p $DATA
 cd $DATA
 
+#############################
 # Execute ex-script
+#############################
 ${HOMEhafs}/scripts/exhafs_forecast.sh
+status=$?
+[[ $status -ne 0 ]] && exit $status
 
+#############################
+# Cleanup DATA after run
+#############################
 export KEEPDATA=${KEEPDATA:-YES}
+cd ${WORKhafs}
 if [ "${KEEPDATA^^}" != YES ]; then
   rm -rf $DATA
 fi

--- a/scripts/exhafs_forecast.sh
+++ b/scripts/exhafs_forecast.sh
@@ -36,6 +36,8 @@ ENSDA=${ENSDA:-NO}
 
 # Set options specific to the deterministic/ensemble forecast
 if [ "${ENSDA}" != YES ]; then
+  FIXgrid=${FIXgrid:-${WORKhafs}/intercom/grid}
+  INPdir=${INPdir:-${WORKhafs}/intercom/chgres}
   NHRS=${NHRS:-126}
   NBDYHRS=${NBDYHRS:-3}
   NOUTHRS=${NOUTHRS_ENS:-3}
@@ -109,6 +111,8 @@ if [ "${ENSDA}" != YES ]; then
   output_grid_dlon=${output_grid_dlon:-0.025}
   output_grid_dlat=${output_grid_dlon:-0.025}
 else
+  FIXgrid=${FIXgrid:-${WORKhafs}/intercom/grid_ens}
+  INPdir=${INPdir:-${WORKhafs}/intercom/chgres_ens/mem${ENSID}}
 # Ensemble member with ENSID <= ${ENS_FCST_SIZE} will run the full-length NHRS forecast
   if [ $((10#${ENSID})) -le ${ENS_FCST_SIZE:-10} ]; then
     NHRS=${NHRS:-126}
@@ -391,7 +395,7 @@ elif [ $gtype = nest ]; then
   fi
 else
   echo "FATAL ERROR: Unsupported gtype of ${gtype}. Currently onnly support gtype of nest or regional."
-  exit 9
+  export err=9; err_chk
 fi
 
 ATM_petlist_bounds=$(printf "ATM_petlist_bounds: %04d %04d" 0 $(($ATM_tasks-1)))
@@ -458,7 +462,7 @@ elif [[ $cpl_atm_ocn = "cmeps"* ]]; then
 # Currently unsupported coupling option combinations
 else
   echo "FATAL ERROR: Unsupported coupling option: cpl_atm_ocn=${cpl_atm_ocn}"
-  exit 9
+  export err=9; err_chk
 fi
 
 fi #if [ ${run_ocean} = yes ] && [ ${run_wave} != yes ]; then
@@ -475,7 +479,7 @@ WAV_model_attribute="WAV_model = ww3"
 # NUOPC based coupling options
 if [[ $cpl_atm_wav = "nuopc"* ]]; then
   echo "FATAL ERROR: Unsupported coupling option combination: cpl_atm_wav=${cpl_atm_wav}"
-  exit 9
+  export err=9; err_chk
 # CMEPS based coupling options
 elif [[ $cpl_atm_wav = "cmeps"* ]]; then
   EARTH_component_list="EARTH_component_list: ATM WAV MED"
@@ -519,7 +523,7 @@ elif [[ $cpl_atm_wav = "cmeps"* ]]; then
 # Currently unsupported coupling option combinations
 else
   echo "FATAL ERROR: Unsupported coupling option combination: cpl_atm_wav=${cpl_atm_wav}"
-  exit 9
+  export err=9; err_chk
 fi
 
 fi #if [ ${run_ocean} != yes ] && [ ${run_wave} = yes ]; then
@@ -597,7 +601,7 @@ elif [ $cpl_atm_ocn = cmeps_sidebyside ] && [ $cpl_atm_wav = cmeps_sidebyside ];
 # Currently unsupported coupling option combinations
 else
   echo "FATAL ERROR: Unsupported coupling options: cpl_atm_ocn=${cpl_atm_ocn}; cpl_atm_wav=${cpl_atm_wav}"
-  exit 9
+  export err=9; err_chk
 fi
 
 fi #if [ ${run_ocean} = yes ] && [ ${run_wave} = yes ]; then
@@ -649,7 +653,7 @@ if [ ${run_datm} = no ]; then
 # Link the input IC and/or LBC files into the INPUT dir
 if [ ! -d $INPdir ]; then
    echo "FATAL ERROR: Input data dir does not exist: $INPdir"
-   exit 9
+   export err=9; err_chk
 fi
 
 # Link all the gfs_bndy files here for full forecast ensemble members, but the
@@ -1275,7 +1279,7 @@ elif [ $gtype = nest ]; then
   ngrids=$(( ${nest_grids} + 1 ))
 else
   echo "FATAL ERROR: Unsupported gtype of ${gtype}. Currently onnly support gtype of nest or regional."
-  exit 9
+  export err=9; err_chk
 fi
 
 for n in $(seq 1 ${ngrids}); do

--- a/ush/hafs_pre_job.sh.inc
+++ b/ush/hafs_pre_job.sh.inc
@@ -58,7 +58,7 @@ elif [[ -d /lfs/h1 && -d /lfs/h2 ]] ; then
      source /usr/share/lmod/lmod/init/$__ms_shell
 #    . /usr/share/lmod/lmod/init/sh
     target=wcoss2
-    module purge
+    module reset
 elif [[ -d /glade ]] ; then
     # We are on NCAR Cheyenne
     if ( ! eval module help > /dev/null 2>&1 ) ; then


### PR DESCRIPTION
Part of HAFS EE2 review

## Description of changes
Provide a fix to HAFS forecast j-job, ex-script, and include to:
(1) Move application logic to ex-script level
(2) User module reset in module include file instead of using purge
(3) Handle clean up DATA with the pwd not in the $DATA directory

## Issues addressed (optional)
Fix know issue found in EE2 review

## Tests conducted
This is not a result changing fix. Does not need to run a test parallel. It can be tested in bundle after all J-Jobs, ex-scripts, and include are organized.