### PR TITLE
Updates to HRDGRAPHICS so it may succeed in the HAFSv1 workflow (both A and B configs).

### DIFF
--- a/scripts/exhafs_hrdgraphics.sh
+++ b/scripts/exhafs_hrdgraphics.sh
@@ -63,7 +63,7 @@ while [[ ${ALL_COMPLETE} -eq 0 ]]; do
 
   # Find and parse the ATCF file into an individual file for each storm
   # Do this even for HAFS regional to remove ".all" from file name.
-  ${GPLOT_PARSE} HAFS ${STORMNUM} ${BASIN} ${COMgplot} ${COMhafs} ${BDECKhafs} ${SYNDAThafs} ${SIDhafs} 0 "*${DATE}.${RUN}.trak.atcfunix.all"
+  ${GPLOT_PARSE} ${RUN^^} ${STORMNUM} ${BASIN} ${COMgplot} ${COMhafs} ${BDECKhafs} ${SYNDAThafs} ${SIDhafs} 0 "*${DATE}.${RUN}.trak.atcfunix.all"
 
   # Check the status logs for all GPLOT components.
   # If every log doesn't say "complete", set ALL_COMPLETE=0
@@ -81,14 +81,14 @@ while [[ ${ALL_COMPLETE} -eq 0 ]]; do
 
   # Check that the final HAFS output has been post-processed by atm_post.
   # If not, set ALL_COMPLETE=0
-  if [ ! -f ${WORKhafs}/forecast/postf${NHR3} ]; then
+  if [ ! -f ${WORKhafs}/intercom/post/postf${NHR3} ]; then
     ALL_COMPLETE=0
     echo "This file doesn't exist --> ${WORKhafs}/forecast/postf${NHR3}"
     echo "That means the final HAFS output has not been post-processed by atm_post."
   fi
 
   # Deliver all new and modified graphics to COMhafs/graphics
-  ${USHhafs}/rsync-no-vanished.sh -av --no-links --include="*/" --include="*gif" --include="*dat" --include="*structure*txt" --exclude="*" ${WORKgplot}/. ${COMgplot}/.
+  ${USHhafs}/rsync-no-vanished.sh -av --no-links --include="*/" --include="*gif" --include="*dat" --include="*structure*txt" --include="*.nc" --exclude="*" ${WORKgplot}/. ${COMgplot}/.
 
   # If all status logs are complete and the final output has been processed
   # by atm_post, then exit with success!
@@ -110,7 +110,7 @@ done
 
 # Now that everything is complete, move all graphics to the $COMhafs directory.
 if [ "${SENDCOM}" == "YES" ]; then
-  ${USHhafs}/rsync-no-vanished.sh -av --no-links --include="*/" --include="*gif" --include="*dat" --include="*structure*txt" --exclude="*" ${WORKgplot}/. ${COMgplot}/.
+  ${USHhafs}/rsync-no-vanished.sh -av --no-links --include="*/" --include="*gif" --include="*dat" --include="*structure*txt" --include="*.nc" --exclude="*" ${WORKgplot}/. ${COMgplot}/.
 fi
 
 echo "graphics job done"


### PR DESCRIPTION
## Description of changes
This PR provides a hotfix (i.e., in this case, updates) to the HRDGRAPHICS task so it may successfully run in the HAFS v1 workflow.

## Issues addressed (optional)
No specific issues to link. However, HRD's testing revealed that the HRDGRAPHICS task was failing because:
1) It could not parse the ATCF correctly
2) It did not know the new location of the postf### files to check the status of the POST task
3) It was not syncing new NetCDF files that are created by HRDGRAPHICS to the ${COMhafs} directory

## Contributors (optional)
If others worked on this PR besides the author, please include their user names here (using @Mention if possible).
@AndrewHazelton @lgramer 

## Tests conducted
Testing has been performed on Hera and Orion. I don't expect any surprises on Jet. Testing involved running the HAFS workflow with the HRDGRAPHICS task turned on. All tests completed successfully.

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
