### PR TITLE
Fix the occasional launch job failures on Orion

### DIFF
--- a/ush/hafs_pre_job.sh.inc
+++ b/ush/hafs_pre_job.sh.inc
@@ -51,7 +51,7 @@ elif [[ -d /work/noaa ]] ; then
   module use /apps/contrib/modulefiles
   module use /apps/contrib/NCEPLIBS/lib/modulefiles
   module use /apps/contrib/NCEPLIBS/orion/modulefiles
-# ulimit -s unlimited
+  ulimit -s unlimited
 elif [[ -d /lfs/h1 && -d /lfs/h2 ]] ; then
   # We are on NOAA WCOSS2
   echo load the module command 1>&2

--- a/ush/hafs_runcmd.sh.inc
+++ b/ush/hafs_runcmd.sh.inc
@@ -14,10 +14,6 @@ export KMP_STACKSIZE=${KMP_STACKSIZE:-2048m}
 #export OMP_STACKSIZE=${OMP_STACKSIZE:-2048m}
 # Avoild "NetCDF: HDF error"
 export HDF5_USE_FILE_LOCKING=FALSE
-# Special command needed on Orion to avoid unexpected job failures
-if [ "$machine" = orion ]; then
-  ulimit -s unlimited
-fi
 
 # Set job run commands
 # APRUN:  command to run general jobs


### PR DESCRIPTION
## Description of changes
This PR fixes the occasional HAFS launch job failures on Orion due to out of stack size/memory issue when creating the regional_esg grid. Moving "ulimit -s unlimited" for Orion from ush/hafs_runcmd.sh.inc to ush/hafs_pre_job.sh.inc can solve those launch job failures on Orion.
 
Note: please make sure "ulimit -s unlimited" is also in your Orion .bashrc file (or its counterpart).

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes hafs-community/HAFS/issues/205

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests, including relevant details about the configuration(s) (e.g., cold versus warm start, number of cycles, forecast length, whether data assimilation was performed, etc). What platform(s) were used for testing?

Tests on Orion were successful. And since this only affects Orion, the HAFS application level RTs are only needed on Orion.

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [N/A] Jet
- [N/A] Hera
- [x] Orion
- [N/A] WCOSS2
