### PR TITLE
Add vortex initialization capability to relocate and warm-cycle cloud variables

### DIFF
--- a/parm/hafs.conf
+++ b/parm/hafs.conf
@@ -336,6 +336,7 @@ vi_bogus_vmax_threshold=50       ;; m/s
 vi_storm_env=init                ;; init: from gfs/gdas init; pert: from the same source for the storm perturbation
 vi_storm_relocation=yes
 vi_storm_modification=auto       ;; yes: always VM; no: no VM; auto: do VM based on vmax diff; vmax_threshold: do VM based on vmax threshold
+vi_cloud=0                       ;; 0: No cloud&vertical velocity modification as same as HAFSv1; 1: GFDL & partial Thompson microphysics 2:Thompson microphysics
 vi_adjust_intensity=yes          ;; place holder
 vi_adjust_size=yes               ;; place holder
 

--- a/parm/hafs_holdvars.conf
+++ b/parm/hafs_holdvars.conf
@@ -51,6 +51,7 @@ vi_storm_relocation={vi/vi_storm_relocation}
 vi_storm_modification={vi/vi_storm_modification}
 vi_adjust_intensity={vi/vi_adjust_intensity}
 vi_adjust_size={vi/vi_adjust_size}
+vi_cloud={vi/vi_cloud}
 
 atm_merge_method={atm_merge/atm_merge_method}
 analysis_merge_method={analysis_merge/analysis_merge_method}

--- a/parm/hafs_holdvars.txt
+++ b/parm/hafs_holdvars.txt
@@ -92,6 +92,7 @@ export vi_storm_relocation={vi_storm_relocation}
 export vi_storm_modification={vi_storm_modification}
 export vi_adjust_intensity={vi_adjust_intensity}
 export vi_adjust_size={vi_adjust_size}
+export vi_cloud={vi_cloud}
 
 export atm_merge_method={atm_merge_method}
 export analysis_merge_method={analysis_merge_method}

--- a/parm/hafs_v1p1a.conf
+++ b/parm/hafs_v1p1a.conf
@@ -29,6 +29,8 @@ ccpp_suite_nest_init=FV3_HAFS_v1_thompson
 
 [vi]
 vi_warm_start_vmax_threshold=20
+vi_storm_modification=yes
+vi_cloud=2
 
 [gsi]
 use_bufr_nr=yes

--- a/scripts/exhafs_atm_vi.sh
+++ b/scripts/exhafs_atm_vi.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -xe
+vi_cloud=${vi_cloud:-0}
 vi_force_cold_start=${vi_force_cold_start:-no}
 vi_min_wind_for_init=${vi_min_wind_for_init:-9} # m/s
 vi_warm_start_vmax_threshold=$(printf "%.0f" ${vi_warm_start_vmax_threshold:-20}) # m/s
@@ -128,6 +129,7 @@ if [[ ${vmax_vit} -ge ${vi_warm_start_vmax_threshold} ]] && [ -d ${RESTARTinp} ]
         --tcvital=${tcvital} \
         --vortexradius=${vortexradius} --res=${res} \
         --nestdoms=$((${nest_grids:-1}-1)) \
+        --vi_cloud=${vi_cloud} \
         --out_file=vi_inp_${vortexradius}deg${res/\./p}.bin
     status=$?; [[ $status -ne 0 ]] && exit $status
     if [[ ${nest_grids} -gt 1 ]]; then
@@ -158,6 +160,7 @@ for vortexradius in 30 45; do
       --tcvital=${tcvital} \
       --vortexradius=${vortexradius} --res=${res} \
       --nestdoms=$((${nest_grids:-1}-1)) \
+      --vi_cloud=${vi_cloud} \
       --out_file=vi_inp_${vortexradius}deg${res/\./p}.bin
   status=$?; [[ $status -ne 0 ]] && exit $status
   if [[ ${nest_grids} -gt 1 ]]; then
@@ -227,7 +230,7 @@ if [[ ${vmax_vit} -ge ${vi_warm_start_vmax_threshold} ]] && [ -d ${RESTARTinp} ]
   ibgs=0
   iflag_cold=0
   crfactor=${crfactor:-1.0}
-  echo ${gesfhr} $ibgs $vmax_vit $iflag_cold $crfactor | ${APRUNO} ./hafs_vi_split.x
+  echo ${gesfhr} $ibgs $vmax_vit $iflag_cold $crfactor ${vi_cloud} | ${APRUNO} ./hafs_vi_split.x
 
   # anl_pert
   work_dir=${DATA}/anl_pert_guess
@@ -337,7 +340,7 @@ if true; then
     ibgs=2
     iflag_cold=1
   fi
-  echo ${gesfhr} $ibgs $vmax_vit $iflag_cold 1.0 | ${APRUNO} ./hafs_vi_split.x
+  echo ${gesfhr} $ibgs $vmax_vit $iflag_cold 1.0 ${vi_cloud} | ${APRUNO} ./hafs_vi_split.x
 
   # anl_pert
   work_dir=${DATA}/anl_pert_init
@@ -409,16 +412,16 @@ if [[ ${vmax_vit} -ge ${vi_bogus_vmax_threshold} ]] && [ ! -s ../anl_pert_guess/
   ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.72
   ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.73
   ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.74
-  ${NLN} ${FIXhafs}/fix_vi/hafs_storm_30       fort.75
-  ${NLN} ${FIXhafs}/fix_vi/hafs_storm_30       fort.76
-  ${NLN} ${FIXhafs}/fix_vi/hafs_storm_30       fort.77
+  ${NLN} ${FIXhafs}/fix_vi/hafs_storm_deep     fort.75
+  ${NLN} ${FIXhafs}/fix_vi/hafs_storm_shallow  fort.76
+  ${NLN} ${FIXhafs}/fix_vi/hafs_storm_shallow  fort.77
   ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.78
 
   # output
   ${NLN} storm_anl_bogus                       fort.56
 
   ${NCP} -p ${EXEChafs}/hafs_vi_anl_bogus.x ./
-  echo 6 ${pubbasin2} | ${APRUNO} ./hafs_vi_anl_bogus.x
+  echo 6 ${pubbasin2} ${vi_cloud} | ${APRUNO} ./hafs_vi_anl_bogus.x
   ${NCP} -p storm_anl_bogus storm_anl
 
 else # warm-start from prior cycle or cold start from global/parent model
@@ -464,7 +467,7 @@ else # warm-start from prior cycle or cold start from global/parent model
   gfs_flag=${gfs_flag:-6}
 
   ${NCP} -p ${EXEChafs}/hafs_vi_anl_combine.x ./
-  echo ${gesfhr} ${pubbasin2} ${gfs_flag} ${initopt} | ${APRUNO} ./hafs_vi_anl_combine.x
+  echo ${gesfhr} ${pubbasin2} ${gfs_flag} ${initopt} ${vi_cloud} | ${APRUNO} ./hafs_vi_anl_combine.x
   if [ -s storm_anl_combine ]; then
     ${NCP} -p storm_anl_combine storm_anl
   fi
@@ -486,9 +489,9 @@ else # warm-start from prior cycle or cold start from global/parent model
     ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.72
     ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.73
     ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.74
-    ${NLN} ${FIXhafs}/fix_vi/hafs_storm_30       fort.75
-    ${NLN} ${FIXhafs}/fix_vi/hafs_storm_30       fort.76
-    ${NLN} ${FIXhafs}/fix_vi/hafs_storm_30       fort.77
+    ${NLN} ${FIXhafs}/fix_vi/hafs_storm_deep     fort.75
+    ${NLN} ${FIXhafs}/fix_vi/hafs_storm_shallow  fort.76
+    ${NLN} ${FIXhafs}/fix_vi/hafs_storm_shallow  fort.77
     ${NLN} ${FIXhafs}/fix_vi/hafs_storm_axisy_47 fort.78
 
     # output
@@ -496,7 +499,7 @@ else # warm-start from prior cycle or cold start from global/parent model
 
     iflag_cold=${iflag_cold:-0}
     ${NCP} -p ${EXEChafs}/hafs_vi_anl_enhance.x ./
-    echo 6 ${pubbasin2} ${iflag_cold} | ${APRUNO} ./hafs_vi_anl_enhance.x
+    echo 6 ${pubbasin2} ${iflag_cold} ${vi_cloud} | ${APRUNO} ./hafs_vi_anl_enhance.x
     ${NCP} -p storm_anl_enhance storm_anl
   fi
 
@@ -532,6 +535,7 @@ for nd in $(seq 1 ${nest_grids}); do
       --relaxzone=30 \
       --infile_date=${CDATE:0:8}.${CDATE:8:2}0000 \
       --nestdoms=$((${nd}-1)) \
+      --vi_cloud=${vi_cloud} \
       --out_dir=${RESTARTout}
   status=$?; [[ $status -ne 0 ]] && exit $status
 done

--- a/sorc/hafs_tools.fd/sorc/hafs_datool/hafs_datool.f90
+++ b/sorc/hafs_tools.fd/sorc/hafs_datool/hafs_datool.f90
@@ -4,6 +4,11 @@
 ! HAFS DA tool
 ! Yonghui Weng, 20210201
 
+!------------------------------------------------------------------------------
+! June 2023: New input argument "vi_cloud" is introduced for vi_preproc & vi_postproc
+! vi_cloud=1 or 2 (cloud remapping for VI, 1:GFDL, 2:Thompson),vi_cloud=0 (no cloud changes in VI: i.e., HFSAv1)
+!------------------------------------------------------------------------------
+
 ! command convention
 !  hafs_datool.x FUNCTION --in_file=input_files \
 !                         --in_grid=input_grids_file \
@@ -51,17 +56,19 @@
 !                             --out_grid=${out_dir}/grid_spec.nc \
 !                             --out_file=20190829.060000.phy_data.nc
 !
-!    3.3) vi_preproc
+!    3.3) vi_preproc: New input argument "vi_cloud" is introduced
 !       * hafs_datool.x hafsvi_preproc --in_dir=HAFS_restart_folder --infile_date=20200825.180000 \
 !                                 [--vortexposition=user_define_vortex_file --tcvital=tcvitalfile \
 !                                  --besttrack=bdeckfile ] [--vortexradius=deg ] \
 !                                 [--nestdoms=nestdoms ] \
+!                                 [--vi_cloud=vi_cloud ] \
 !                                 [ --tc_date=tcvital_date] [--res=deg ] \
 !                                 [--out_file=output_bin_file or nc_file]
 !
-!    3.4) vi_postproc
+!    3.4) vi_postproc: New input argument "vi_cloud" is introduced
 !       * hafs_datool.x hafsvi_postproc --in_file=[hafs_vi rot-ll bin file] \
 !                                       --out_dir=[hafs-restart subfolder]  \
+!                                       --vi_cloud=vi_cloud  \
 !                                       --infile_date=20200825.180000
 !=========================================================================
   use module_mpi
@@ -85,6 +92,7 @@
   character (len=50  ) :: interpolation_pointsc='' !
   character (len=50  ) :: nestdomsc=''      ! number for nest domains, 1-30, 1=nest02.tile2
                                             ! in vi_preproc, combine all domains and output to one rot-ll grid.
+  character (len=50  ) :: vi_cloud='w'      ! Cloud remapping for VI, 1:GFDL, 2:Thompson & 0: No cloud remapping
 
   real, dimension(3)   :: center
 !----------------------------------------------------------------
@@ -124,6 +132,7 @@
                case ('--debug_level');    debug_levelc=arg(j+1:n)  !
                case ('--interpolation_points'); interpolation_pointsc=arg(j+1:n)  !
                case ('--nestdoms');       nestdomsc=arg(j+1:n)  !
+               case ('--vi_cloud');       vi_cloud=arg(j+1:n)      !
         end select
      enddo
   endif
@@ -198,15 +207,17 @@
   if ( trim(actions) == "hafsvi_preproc" ) then
      write(*,'(a)')' --- call hafsvi_preproc/hafs_datool for '//trim(in_grid)
      if ( index(trim(out_file),'.nc') > 1 ) then
-        call hafsvi_preproc_nc(trim(in_dir), trim(infile_date), nestdoms, trim(vortexradius), trim(res), trim(out_file))
+        call hafsvi_preproc_nc(trim(in_dir), trim(infile_date), nestdoms, trim(vortexradius), trim(res), trim(out_file), &
+        trim(vi_cloud))
      else
-        call hafsvi_preproc(trim(in_dir), trim(infile_date), nestdoms, trim(vortexradius), trim(res), trim(out_file))
+        call hafsvi_preproc(trim(in_dir), trim(infile_date), nestdoms, trim(vortexradius), trim(res), trim(out_file), &
+        trim(vi_cloud))
      endif
   endif
 
   if ( trim(actions) == "hafsvi_postproc" ) then
      write(*,'(a)')' --- call hafsvi_postproc/hafs_datool for '//trim(in_file)
-     call hafsvi_postproc(trim(in_file), trim(infile_date), trim(out_dir), nestdoms)
+     call hafsvi_postproc(trim(in_file), trim(infile_date), trim(out_dir), nestdoms, trim(vi_cloud))
   endif
 
 !----------------------------------------------------------------

--- a/sorc/hafs_tools.fd/sorc/hafs_datool/sub_hafsvi_proc.f90
+++ b/sorc/hafs_tools.fd/sorc/hafs_datool/sub_hafsvi_proc.f90
@@ -1,9 +1,22 @@
 !========================================================================================
-  subroutine hafsvi_preproc(in_dir, in_date, nestdoms, radius, res, out_file)
+  subroutine hafsvi_preproc(in_dir, in_date, nestdoms, radius, res, out_file, vi_cloud)
 
 !-----------------------------------------------------------------------------
 ! HAFS DA tool - hafsvi_preproc
 ! Yonghui Weng, 20211210
+!
+! Big Change/Update by JungHoon: Feb~July, 2023
+! New input argument "vi_cloud" is introduced
+! If input argument "vi_cloud" is 0, it will handle 17 variables
+! If input argument "vi_cloud" is 1, it will handle 22 variables
+! If input argument "vi_cloud" is 2, it will handle 24 variables
+!
+! 0: NO cloud changes in VI and handles only 17 variables as same as original sub_hafsvi_proc.f90
+! 1: (GFDL microphysics) handles 5 more variables cloud water, rain water, ice, snow, graupel (22 variables)
+! 2: Thompson microphysics: Need to handle two more additional variables (below) on the top of option 1
+! ice water number concentration and rain number concentration (24 variables)
+!
+! These new cloud variables are extracted from fv_tracer.res.tile1.nc
 !
 ! This subroutine read hafs restart files and output hafsvi needed input.
 ! Variables needed:
@@ -25,7 +38,15 @@
 !      WRITE(IUNIT) land                  ! =A101 = land sea mask, B101 = ZNT
 !      WRITE(IUNIT) sfcr                  ! =B101 = Z0
 !      WRITE(IUNIT) C101                  ! =C101 = (10m wind speed)/(level 1 wind speed)
-!
+! 5 new variables added for GFDL microphysics: Feb, 2023 (below)
+!      WRITE(IUNIT) (((qc(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qr(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qi(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qs(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qg(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+! 2 new addiontal variables added for Thompson microphysics: Jul, 2023 (below)
+!      WRITE(IUNIT) (((NCI(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((NCR(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
 
 !-----------------------------------------------------------------------------
 
@@ -36,7 +57,7 @@
 
   implicit none
 
-  character (len=*), intent(in) :: in_dir, in_date, radius, res, out_file
+  character (len=*), intent(in) :: in_dir, in_date, radius, res, out_file, vi_cloud
   integer, intent(in)           :: nestdoms
 !--- in_dir,  HAFS_restart_folder, which holds grid_spec.nc, fv_core.res.tile1.nc,
 !             fv_srf_wnd.res.tile1.nc, fv_tracer.res.tile1.nc, phy_data.nc, sfc_data.nc
@@ -57,6 +78,8 @@
 
 !----for hafs restart
   integer  :: ix, iy, iz, kz, ndom, nd
+  integer  :: itotal_var !  Total number of variables handled in this
+                         !  subrotine: yes=22 variables, no=17 variables
   character (len=50) :: nestfl, tilefl, tempfl
                         ! grid_spec.nc : grid_spec.nest02.tile2.nc
                         ! fv_core.res.tile1.nc : fv_core.res.nest02.tile2.nc
@@ -80,6 +103,12 @@
   real    :: cputime1, cputime2, cputime3
   integer :: io_proc, nm, ks, ke, nv
 
+! If input argument is no, only handle 17 variables.
+  if (trim(vi_cloud) == '0') itotal_var=17
+! If input argument is 1, handle 22 variables for GFDL microphysics.
+  if (trim(vi_cloud) == '1') itotal_var=22
+! If input argument is 2, handle 24 variables for Thompson microphysics.
+  if (trim(vi_cloud) == '2') itotal_var=24
 
 !------------------------------------------------------------------------------
 ! 1 --- arg process
@@ -256,7 +285,7 @@
 
      !-------------------------------------------------------------------------
      ! 7 --- output
-     do_out_var_loop: do nrecord = 1, 17
+     do_out_var_loop: do nrecord = 1, itotal_var
         !write(*,*)my_proc_id, '=== nrecord =',nrecord
         !-----------------------------
         !---7.1 record 1: nx, ny, nz
@@ -381,13 +410,31 @@
         !---7.4 record 4: (((tmp(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
         !---7.5 record 5: (((spfh(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
         !---7.8 record 8: (((dzdt(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
-        if ( nrecord == 4 .or. nrecord == 5 .or. nrecord == 8 ) then
+        !---7.18 record 18: (((qc(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.19 record 19: (((qr(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.20 record 20: (((qi(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.21 record 21: (((qs(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.22 record 22: (((qg(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---Below two variables are needed for Thompson microphysics
+        !---7.23 record 23: (((nnqi(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.24 record 24: (((nnqr(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        if ( nrecord == 4 .or.  nrecord == 5 .or.  nrecord == 8  &
+        .or. nrecord == 18 .or. nrecord == 19 .or. nrecord == 20 &
+        .or. nrecord == 21 .or. nrecord == 22 .or. nrecord == 23 &
+        .or. nrecord == 24 ) then
            if ( my_proc_id == io_proc ) then
               !---read in
               allocate(dat4(ix, iy, iz,1))
               if ( nrecord == 4 ) call get_var_data(trim(infile_core), 'T', ix, iy, iz,1, dat4)
               if ( nrecord == 5 ) call get_var_data(trim(infile_tracer), 'sphum', ix, iy, iz,1, dat4)
               if ( nrecord == 8 ) call get_var_data(trim(infile_core), 'W', ix, iy, iz,1, dat4)
+              if ( nrecord == 18 ) call get_var_data(trim(infile_tracer), 'liq_wat', ix, iy, iz,1, dat4)
+              if ( nrecord == 19 ) call get_var_data(trim(infile_tracer), 'rainwat', ix, iy, iz,1, dat4)
+              if ( nrecord == 20 ) call get_var_data(trim(infile_tracer), 'ice_wat', ix, iy, iz,1, dat4)
+              if ( nrecord == 21 ) call get_var_data(trim(infile_tracer), 'snowwat', ix, iy, iz,1, dat4)
+              if ( nrecord == 22 ) call get_var_data(trim(infile_tracer), 'graupel', ix, iy, iz,1, dat4)
+              if ( nrecord == 23 ) call get_var_data(trim(infile_tracer), 'ice_nc', ix, iy, iz,1, dat4)
+              if ( nrecord == 24 ) call get_var_data(trim(infile_tracer), 'rain_nc', ix, iy, iz,1, dat4)
               !---send to other core
               if ( nprocs > 1 ) then
                  nm=max(1,int((iz+nprocs-1)/nprocs))
@@ -641,7 +688,10 @@
         !-----------------------------
         !---7.18 output 3d
         if ( nrecord == 3 .or. nrecord == 4 .or. nrecord == 5 .or. &
-             nrecord == 8 .or. nrecord == 9 .or. nrecord ==11 )then
+             nrecord == 8 .or. nrecord == 9 .or. nrecord ==11 .or. &
+             nrecord ==18 .or. nrecord ==19 .or. nrecord ==20 .or. &
+             nrecord ==21 .or. nrecord ==22 .or. nrecord ==23 .or. &
+             nrecord ==24 )then
            call mpi_barrier(comm,ierr)
            kz=nz
            if ( nrecord ==  9 .or. nrecord == 11 ) then
@@ -907,7 +957,7 @@
            endif  !if ( my_proc_id == io_proc ) then
         endif
 
-     enddo do_out_var_loop !: for nrecord = 1, 17
+     enddo do_out_var_loop !: for nrecord = 1, itotal_var  ! 24 or 22 or 17 variables
 
      !-------------------------------------------------------------------------
      ! 8 --- clean ingrid gwt
@@ -921,11 +971,22 @@
   end subroutine hafsvi_preproc
 
 !========================================================================================
-  subroutine hafsvi_preproc_nc(in_dir, in_date, nestdoms, radius, res, out_file)
+  subroutine hafsvi_preproc_nc(in_dir, in_date, nestdoms, radius, res, out_file, vi_cloud)
 
 !-----------------------------------------------------------------------------
 ! HAFS DA tool - hafsvi_preproc
 ! Yonghui Weng, 20211210
+!
+! Big Change/Update by JungHoon: Feb~July, 2023
+! New input argument "vi_cloud" is introduced
+! If input argument "vi_cloud" is 0, it will handle 17 variables
+! If input argument "vi_cloud" is 1, it will handle 22 variables
+! If input argument "vi_cloud" is 2, it will handle 24 variables
+!
+! 0: NO cloud changes in VI and handles only 17 variables as same as original sub_hafsvi_proc.f90
+! 1: (GFDL microphysics) handles 5 more variables cloud water, rain water, ice, snow, graupel (22 variables)
+! 2: Thompson microphysics: Need to handle two more additional variables (below) on the top of option 1
+! ice water number concentration and rain number concentration (24 variables)
 !
 ! This subroutine read hafs restart files and output hafsvi needed input.
 ! Variables needed:
@@ -947,8 +1008,16 @@
 !      WRITE(IUNIT) land                  ! =A101 = land sea mask, B101 = ZNT
 !      WRITE(IUNIT) sfcr                  ! =B101 = Z0
 !      WRITE(IUNIT) C101                  ! =C101 = (10m wind speed)/(level 1 wind speed)
+! 5 new variables added for GFDL microphysics: Feb, 2023 (below)
+!      WRITE(IUNIT) (((qc(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qr(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qi(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qs(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((qg(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+! 2 new addiontal variables added for Thompson microphysics: Jul, 2023 (below)
+!      WRITE(IUNIT) (((NCI(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+!      WRITE(IUNIT) (((NCR(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
 !
-
 !-----------------------------------------------------------------------------
 
   use constants
@@ -958,7 +1027,7 @@
 
   implicit none
 
-  character (len=*), intent(in) :: in_dir, in_date, radius, res, out_file
+  character (len=*), intent(in) :: in_dir, in_date, radius, res, out_file, vi_cloud
   integer, intent(in)           :: nestdoms
 !--- in_dir,  HAFS_restart_folder, which holds grid_spec.nc, fv_core.res.tile1.nc,
 !             fv_srf_wnd.res.tile1.nc, fv_tracer.res.tile1.nc, phy_data.nc, sfc_data.nc
@@ -979,6 +1048,8 @@
 
 !----for hafs restart
   integer  :: ix, iy, iz, kz, ndom, nd
+  integer  :: itotal_var ! Total number of variables handled in this
+                         ! subrotine: option 2:24, option 1:22, option 0:17
   character (len=50) :: nestfl, tilefl, tempfl
                         ! grid_spec.nc : grid_spec.nest02.tile2.nc
                         ! fv_core.res.tile1.nc : fv_core.res.nest02.tile2.nc
@@ -1003,6 +1074,13 @@
   real    :: cputime1, cputime2, cputime3
   integer :: io_proc, nm, ks, ke, nv
   character (len=50)  :: varname, varname_long, units, nzc
+
+! If input argument is 0, only handle 17 variables.
+  if (trim(vi_cloud) == '0') itotal_var=17
+! If input argument is 1, handle 22 variables for GFDL microphysics.
+  if (trim(vi_cloud) == '1') itotal_var=22
+! If input argument is 2, handle 24 variables for Thompson microphysics.
+  if (trim(vi_cloud) == '2') itotal_var=24
 
 !------------------------------------------------------------------------------
 ! 1 --- arg process
@@ -1218,7 +1296,7 @@
      call mpi_barrier(comm,ierr)
 
      ! 7.2 --- remapp-needed variables:
-     do_out_var_loop: do nrecord = 3, 17
+     do_out_var_loop: do nrecord = 3, itotal_var
         if ( nrecord == 7 .or. nrecord == 10 .or. nrecord == 13 .or. nrecord == 14 ) cycle do_out_var_loop
 
         iz=nz   !same vertical levels
@@ -1264,6 +1342,36 @@
            varname='f10m'
            units='numeric'
            varname_long='(10m wind speed)/(level 1 wind speed)'
+        elseif ( nrecord == 18 ) then
+           varname='liq_wat'
+           units='kg/kg'
+           varname_long='liq_wat'
+        elseif ( nrecord == 19 ) then
+           varname='rainwat'
+           units='kg/kg'
+           varname_long='rainwat'
+        elseif ( nrecord == 20 ) then
+           varname='ice_wat'
+           units='kg/kg'
+           varname_long='ice_wat'
+        elseif ( nrecord == 21 ) then
+           varname='snowwat'
+           units='kg/kg'
+           varname_long='snowwat'
+        elseif ( nrecord == 22 ) then
+           varname='graupel'
+           units='kg/kg'
+           varname_long='graupel'
+        ! For Thompson microphysics nrecord ==23 & 24
+        elseif ( nrecord == 23 ) then
+           varname='ice_nc'
+           units='/kg'
+           varname_long='ice_nc'
+        elseif ( nrecord == 24 ) then
+           varname='rain_nc'
+           units='/kg'
+           varname_long='rain_nc'
+        !-----------------------------
         endif
         nzc='nz'
         if ( iz == nz+1 ) nzc='nz1'
@@ -1370,13 +1478,32 @@
         !---7.4 record 4: (((tmp(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
         !---7.5 record 5: (((spfh(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
         !---7.8 record 8: (((dzdt(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
-        if ( nrecord == 4 .or. nrecord == 5 .or. nrecord == 8 ) then
+        !---7.18 record 18: (((qc(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.19 record 19: (((qr(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.20 record 20: (((qi(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.21 record 21: (((qs(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.22 record 22: (((qg(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---Below two variables are needed for Thompson microphysics
+        !---7.23 record 23: (((nnqi(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        !---7.24 record 24: (((nnqr(i,j,k),i=1,nx),j=1,ny),k=nz,1,-1)
+        if ( nrecord == 4 .or. nrecord == 5 .or. nrecord == 8    &
+        .or. nrecord ==18 .or. nrecord ==19 .or. nrecord ==20    &
+        .or. nrecord ==21 .or. nrecord ==22 .or. nrecord ==23    &
+        .or. nrecord ==24 ) then
            if ( my_proc_id == io_proc ) then
               !---read in
               allocate(dat4(ix, iy, iz,1))
               if ( nrecord == 4 ) call get_var_data(trim(infile_core), 'T', ix, iy, iz,1, dat4)
               if ( nrecord == 5 ) call get_var_data(trim(infile_tracer), 'sphum', ix, iy, iz,1, dat4)
               if ( nrecord == 8 ) call get_var_data(trim(infile_core), 'W', ix, iy, iz,1, dat4)
+              if ( nrecord == 18 ) call get_var_data(trim(infile_tracer), 'liq_wat', ix, iy, iz,1, dat4)
+              if ( nrecord == 19 ) call get_var_data(trim(infile_tracer), 'rainwat', ix, iy, iz,1, dat4)
+              if ( nrecord == 20 ) call get_var_data(trim(infile_tracer), 'ice_wat', ix, iy, iz,1, dat4)
+              if ( nrecord == 21 ) call get_var_data(trim(infile_tracer), 'snowwat', ix, iy, iz,1, dat4)
+              if ( nrecord == 22 ) call get_var_data(trim(infile_tracer), 'graupel', ix, iy, iz,1, dat4)
+              ! For Thompson microphysics nrecord ==23 & 24
+              if ( nrecord == 23 ) call get_var_data(trim(infile_tracer), 'ice_nc', ix, iy, iz,1, dat4)
+              if ( nrecord == 24 ) call get_var_data(trim(infile_tracer), 'rain_nc', ix, iy, iz,1, dat4)
               !---send to other core
               if ( nprocs > 1 ) then
                  nm=max(1,int((iz+nprocs-1)/nprocs))
@@ -1538,7 +1665,10 @@
         !-----------------------------
         !---7.18 output 3d
         if ( nrecord == 3 .or. nrecord == 4 .or. nrecord == 5 .or. &
-             nrecord == 8 .or. nrecord == 9 .or. nrecord ==11 )then
+             nrecord == 8 .or. nrecord == 9 .or. nrecord ==11 .or. &
+             nrecord ==18 .or. nrecord ==19 .or. nrecord ==20 .or. &
+             nrecord ==21 .or. nrecord ==22 .or. nrecord ==23 .or. &
+             nrecord ==24 )then
            call mpi_barrier(comm,ierr)
            kz=nz
            if ( nrecord ==  9 .or. nrecord == 11 ) then
@@ -1805,7 +1935,7 @@
            endif  !if ( my_proc_id == io_proc ) then
         endif
 
-     enddo do_out_var_loop !: for nrecord = 1, 17
+     enddo do_out_var_loop !: for nrecord = 1, itotal_var  !We have 17 or 22 or 24 variables now
 
      !-------------------------------------------------------------------------
      ! 8 --- clean ingrid gwt
@@ -1819,11 +1949,26 @@
   end subroutine hafsvi_preproc_nc
 
 !========================================================================================
-  subroutine hafsvi_postproc(in_file, in_date, out_dir, nestdoms)
+  subroutine hafsvi_postproc(in_file, in_date, out_dir, nestdoms, vi_cloud)
 
 !-----------------------------------------------------------------------------
 ! HAFS DA tool - hafsvi_postproc
 ! Yonghui Weng, 20220121
+!
+! Change/Update: Feb 11, 2023
+! Original hafsvi_postproc was designed to handle 14 variables, but new code is
+! changed to handle 5 more variables cloud water, rain water, ice, snow, graupel
+!
+! Change/Update: May, 2023
+! Includes Yonghui's fix: Changing from size(dat43) to size(dat44) in the below part
+! call mpi_recv(dat44, size(dat44), mpi_real, io_proc, 200*nv+ks, comm, status, ierr)
+!
+! FINAL Change/Update: July, 2023
+! New input argument "vi_cloud" is introduced, which shoulde be LOWER CASE
+! 0: NO cloud changes in VI and handles only 14 variables as same as original
+! sub_hafsvi_proc.f90
+! 1: GFDL scheme handles 19 variables, including 5 cloud variables as described in above
+! 2: Thompson scheme handles 21 variables, including 7 cloud variables as described in above
 !
 ! This subroutine reads hafs_vi binary output file and merge it to hafs restart files.
 ! hafs_vi binary output:
@@ -1842,6 +1987,13 @@
 !      WRITE(IUNIT) PD1
 !      WRITE(IUNIT) ETA1
 !      WRITE(IUNIT) ETA2
+!      WRITE(IUNIT) QC   !New variable added in 2023
+!      WRITE(IUNIT) QR   !New variable added in 2023
+!      WRITE(IUNIT) QI   !New variable added in 2023
+!      WRITE(IUNIT) QS   !New variable added in 2023
+!      WRITE(IUNIT) QG   !New variable added in 2023
+!      WRITE(IUNIT) NCI  !New variable added in 2023
+!      WRITE(IUNIT) NCR  !New variable added in 2023
 !
 !      ALLOCATE ( T1(NX,NY,NZ),Q1(NX,NY,NZ) )
 !      ALLOCATE ( U1(NX,NY,NZ),V1(NX,NY,NZ),DZDT(NX,NY,NZ) )
@@ -1852,6 +2004,9 @@
 !      ALLOCATE ( HLON(NX,NY),HLAT(NX,NY) )
 !      ALLOCATE ( VLON(NX,NY),VLAT(NX,NY) )
 !      ALLOCATE ( PMID1(NX,NY,NZ),ZMID1(NX,NY,NZ) )
+!      ALLOCATE ( QC(NX,NY,NZ),QR(NX,NY,NZ),QI(NX,NY,NZ) )
+!      ALLOCATE ( QS(NX,NY,NZ),QG(NX,NY,NZ) )
+!      ALLOCATE ( NCI(NX,NY,NZ),NCR(NX,NY,NZ) )
 
 !-----------------------------------------------------------------------------
 
@@ -1864,6 +2019,7 @@
 
   character (len=*), intent(in) :: in_file,  & ! The VI output binary file on 30x30degree
                                    in_date,  & ! HAFS_restart file date, like 20200825.120000
+                                   vi_cloud, & ! 0: As same as original code, NO cloud remapping, 1: GFDL, 2: Thompson
                                    out_dir     ! HAFS_restart_folder, which holds grid_spec.nc, fv_core.res.tile1.nc,
                                                ! fv_srf_wnd.res.tile1.nc, fv_tracer.res.tile1.nc, phy_data.nc, sfc_data.nc
   integer, intent(in)           :: nestdoms
@@ -1883,6 +2039,8 @@
 
 !----for hafsvi
   integer  :: nx, ny, nz, i360, filetype  ! filetype: 1=bin, 2=nc
+  integer  :: itotal_var !Total number of variables handled in this
+                         !subrotine: option=0: 14 variables, option=1:19 variables,option=2: 21 variables
   real     :: lon1,lat1,lon2,lat2,cen_lat,cen_lon,dlat,dlon
   real, allocatable, dimension(:,:) :: hlon, hlat, vlon, vlat
 
@@ -1897,6 +2055,13 @@
   real, allocatable, dimension(:,:)     :: cangu, sangu, cangv, sangv
 
   integer :: io_proc, nm, ks, ke, nv
+
+! If input argument is 0, only handle 14 variables.
+  if (trim(vi_cloud) == '0') itotal_var=14
+! If input argument is 1, handle 19 variables for GFDL microphysics.
+  if (trim(vi_cloud) == '1') itotal_var=19
+! If input argument is 2, handle 21 variables for Thompson microphysics.
+  if (trim(vi_cloud) == '2') itotal_var=21
 
 !------------------------------------------------------------------------------
 ! 1 --- arg process
@@ -2015,7 +2180,7 @@
 
      !-------------------------------------------------------------------------
      ! 5 --- process record one-by-one
-     do_record_loop: do nrecord = 1, 14
+     do_record_loop: do nrecord = 1, itotal_var
 
         if ( my_proc_id == io_proc ) open(iunit, file=trim(in_file), form='unformatted')
 
@@ -2117,13 +2282,24 @@
         endif  !if ( nrecord == 6 ) then   !u,v - 6,7
 
         if ( nrecord == 4 .or. nrecord == 5 .or. nrecord == 8 .or. &
-             nrecord == 9 .or. nrecord == 11 ) then
+             nrecord == 9 .or. nrecord ==11 .or.                   &
+             nrecord ==15 .or. nrecord ==16 .or. nrecord ==17 .or. &
+             nrecord ==18 .or. nrecord ==19 .or. nrecord ==20 .or. &
+             nrecord ==21 ) then
            !---record 4 : t1-->T
            !---record 5 : Q1
            !---record 8 : DZDT
            !---record 9 : z1 --> DZ
            !---record 11: p1-->delp, p1(nx,ny,nz+1): (((p1(i,j,k),i=1,nx),j=1,ny),k=nz+1,1,-1)
            !---           p1-->ps
+           !---record 15: QC
+           !---record 16: QR
+           !---record 17: QI
+           !---record 18: QS
+           !---record 19: QG
+           !---Below two varialbes are for Thompson scheme only
+           !---record 20: NCI
+           !---record 21: NCR
            iz=nz
            if ( my_proc_id == io_proc ) then
               !---get data
@@ -2319,7 +2495,10 @@
               deallocate(u1, v1)
            endif
         elseif ( nrecord == 4 .or. nrecord == 5 .or. nrecord == 8 .or. &
-                 nrecord == 9 .or. nrecord == 11 ) then
+                 nrecord == 9 .or. nrecord == 11 .or.   &
+                 nrecord ==15 .or. nrecord == 16 .or. nrecord ==17 .or. &
+                 nrecord ==18 .or. nrecord == 19 .or. nrecord ==20 .or. &
+                 nrecord ==21 ) then
            iz=nz
            nm=max(1,int((iz+nprocs-1)/nprocs))
            if ( my_proc_id == io_proc ) then
@@ -2330,6 +2509,14 @@
               if ( nrecord == 8 ) call get_var_data(trim(ncfile_core), 'W', ix, iy, iz,1, dat4)
               if ( nrecord == 9 ) call get_var_data(trim(ncfile_core), 'DZ', ix, iy, iz,1, dat4)
               if ( nrecord == 11 ) call get_var_data(trim(ncfile_core), 'delp', ix, iy, iz,1, dat4)
+              if ( nrecord == 15 ) call get_var_data(trim(ncfile_tracer), 'liq_wat', ix, iy, iz,1, dat4)
+              if ( nrecord == 16 ) call get_var_data(trim(ncfile_tracer), 'rainwat', ix, iy, iz,1, dat4)
+              if ( nrecord == 17 ) call get_var_data(trim(ncfile_tracer), 'ice_wat', ix, iy, iz,1, dat4)
+              if ( nrecord == 18 ) call get_var_data(trim(ncfile_tracer), 'snowwat', ix, iy, iz,1, dat4)
+              if ( nrecord == 19 ) call get_var_data(trim(ncfile_tracer), 'graupel', ix, iy, iz,1, dat4)
+              ! For Thompson microphysics only nrecord ==20 & 21
+              if ( nrecord == 20 ) call get_var_data(trim(ncfile_tracer), 'ice_nc',  ix, iy, iz,1, dat4)
+              if ( nrecord == 21 ) call get_var_data(trim(ncfile_tracer), 'rain_nc', ix, iy, iz,1, dat4)
 
               !---send data to other cores
               if ( nprocs > 1 ) then
@@ -2408,6 +2595,14 @@
               if ( nrecord == 8 ) call update_hafs_restart(trim(ncfile_core), 'W', ix, iy, iz, 1, dat41)
               if ( nrecord == 9 ) call update_hafs_restart(trim(ncfile_core), 'DZ', ix, iy, iz, 1, dat41)
               if ( nrecord ==11 ) call update_hafs_restart(trim(ncfile_core), 'delp', ix, iy, iz, 1, dat41)
+              if ( nrecord ==15 ) call update_hafs_restart(trim(ncfile_tracer), 'liq_wat', ix, iy, iz, 1, dat41)
+              if ( nrecord ==16 ) call update_hafs_restart(trim(ncfile_tracer), 'rainwat', ix, iy, iz, 1, dat41)
+              if ( nrecord ==17 ) call update_hafs_restart(trim(ncfile_tracer), 'ice_wat', ix, iy, iz, 1, dat41)
+              if ( nrecord ==18 ) call update_hafs_restart(trim(ncfile_tracer), 'snowwat', ix, iy, iz, 1, dat41)
+              if ( nrecord ==19 ) call update_hafs_restart(trim(ncfile_tracer), 'graupel', ix, iy, iz, 1, dat41)
+              ! For Thompson microphysics only nrecord ==20 & 21
+              if ( nrecord ==20 ) call update_hafs_restart(trim(ncfile_tracer), 'ice_nc',  ix, iy, iz, 1, dat41)
+              if ( nrecord ==21 ) call update_hafs_restart(trim(ncfile_tracer), 'rain_nc', ix, iy, iz, 1, dat41)
               deallocate(dat41)
 
               !---2d phis

--- a/sorc/hafs_tools.fd/sorc/hafs_vi/anl_bogus/anl_bogus.f90
+++ b/sorc/hafs_tools.fd/sorc/hafs_vi/anl_bogus/anl_bogus.f90
@@ -7,13 +7,24 @@
 ! ABSTRACT
 !
 !     DECLARE VARIABLES
+! REVISED  AUTHOR: JungHoon Shin July 2023 NCEP/EMC
+!                  For bogus part, VI code simply reads cloud variables from
+!                  30 by 30 degrees GFS input data (fort.36) and relocates them
+!                  This change requires changes in exhafs_atm_vi.sh
+!                  The code is updated further with one more input argument (ivi_cloud)
+!                  so that cloud modification can be on (1 or 2) or off (0).
+!                  0: No cloud changes in VI, 1: GFDL microphysics, 2: Thompson microphysics
+!                  Now input arguement is like this:
+!  ./hafs_vi_anl_bogus.x 6 ${pubbasin2} ${vi_cloud}
+!______________________________________________________________________________
 !
       IMPLICIT NONE
       INTEGER I,J,K,L,M,N,NX,NY,NZ,NX1,NY1,NZ1,NZ2,JX,JY,KMX,ICH
       integer NST,IT,ID,JD,IR,IR1,ITIM,IUNIT,I360,IM1,JM1,JX1,IMV,JMV
       integer ictr,jctr,imn1,imx1,jmn1,jmx1,KST,imax1,jmax1,iter,ics
       integer id_storm,ICLAT,ICLON,Ipsfc,Ipcls,Irmax,ivobs,Ir_vobs
-      integer i_psm,j_psm,ix2,jx2
+      integer i_psm,j_psm,ix2,jx2,icst,jcst
+      integer nd,irange,nw,iwrange,nk,meltlev,nqc,nice,nqr,isnow,n100
       real GAMMA,G,Rd,D608,Cp,COEF1,COEF2,COEF3,GRD,TV1,ZSF1,PSF1,A,DP_CT
       real pi,pi_deg,pi180,rad,arad,SLP1_MEAN,SUM11,SLP_AVE,SLP_SUM,SLP_MIN
       real vobs,vobs_o,VRmax,psfc_obs,psfc_cls,PRMAX,Rctp,cost,dp_obs,z0
@@ -44,6 +55,13 @@
       REAL(4), ALLOCATABLE :: Z1(:,:,:),P1(:,:,:)
       REAL(4), ALLOCATABLE :: GLON(:,:),GLAT(:,:)
       REAL(4), ALLOCATABLE :: PD1(:,:),ETA1(:),ETA2(:)
+      REAL(4), ALLOCATABLE :: QC4(:,:,:),QR4(:,:,:),QS4(:,:,:)   !GFS cloud on hybrid level
+      REAL(4), ALLOCATABLE :: QI4(:,:,:),QG4(:,:,:)              !GFS cloud on hybrid level
+      REAL(4), ALLOCATABLE :: NCI4(:,:,:),NCR4(:,:,:)            !GFS cloud concentration on hybrid level
+      REAL(4), ALLOCATABLE :: QCP(:,:,:),QRP(:,:,:),QSP(:,:,:)   !GFS cloud on P level
+      REAL(4), ALLOCATABLE :: QIP(:,:,:),QGP(:,:,:),DZDTP(:,:,:) !GFS cloud & W on P level
+      REAL(4), ALLOCATABLE :: NCIP(:,:,:),NCRP(:,:,:)            !GFS cloud concentration on P level
+      REAL(4), ALLOCATABLE :: PM4(:,:,:)      ! GFS model pressure
 
       REAL(4), ALLOCATABLE :: USCM(:,:),VSCM(:,:)        ! Env. wind at new grids
 
@@ -109,6 +127,8 @@
 
       REAL(4), ALLOCATABLE :: dist(:,:)
 
+      integer(4), ALLOCATABLE :: itag_c(:,:),itag_w(:,:) ! Tag array for cloud & W relocation
+
       integer(4) IH1(4),JH1(4),IV1(4),JV1(4)
 
       REAL(8) CLON_NEW,CLAT_NEW,CLON_NHC,CLAT_NHC
@@ -120,6 +140,8 @@
       integer Ir_v4(4)
       CHARACTER SN*1,EW*1,DEPTH*1
       CHARACTER*2 basin
+!shin: cloud modification option
+      integer :: ivi_cloud
 
 !using      DATA PW_S/42*1.0,0.95,0.9,0.85,0.8,0.75,0.7,       &
 !using	        0.65,0.6,0.55,0.5,0.45,0.4,0.35,0.3,     &
@@ -149,8 +171,12 @@
 
       arad=6.371E6*rad
 
-      READ(5,*)ITIM,basin
+      irange = 300        !For cloud relocation
+      nd = 2*irange+1     !For cloud relocation
+      iwrange = 150        !For vertical velocity relocation
+      nw = 2*iwrange+1     !For vertical velocity relocation
 
+      READ(5,*)ITIM,basin,ivi_cloud
 
 ! READ NEW GFS Env. DATA (New Domain)
 
@@ -174,10 +200,16 @@
       ALLOCATE ( USC(NX,NY),VSC(NX,NY) )        ! Env. wind at new grids
 
       ALLOCATE ( T4(NX,NY,NZ),Q4(NX,NY,NZ) )    ! orginal data (GFS analysis data)
+      ALLOCATE ( QC4(NX,NY,NZ),QR4(NX,NY,NZ),QI4(NX,NY,NZ) )
+      ALLOCATE ( QS4(NX,NY,NZ),QG4(NX,NY,NZ),PM4(NX,NY,NZ) )
+      ALLOCATE ( NCI4(NX,NY,NZ),NCR4(NX,NY,NZ) )
+      ALLOCATE ( QCP(NX,NY,KMX),QRP(NX,NY,KMX),QIP(NX,NY,KMX) )
+      ALLOCATE ( QSP(NX,NY,KMX),QGP(NX,NY,KMX),DZDTP(NX,NY,KMX) )
+      ALLOCATE ( NCIP(NX,NY,KMX),NCRP(NX,NY,KMX) )
 
       ALLOCATE ( TEK(NZ) )
 
-      ALLOCATE ( dist(NX,NY) )
+      ALLOCATE ( dist(NX,NY),itag_c(NX,NY), itag_w(NX,NY) )
 
       ALLOCATE ( HLON(NX,NY),HLAT(NX,NY) )
       ALLOCATE ( VLON(NX,NY),VLAT(NX,NY) )
@@ -189,7 +221,7 @@
       READ(IUNIT) Q1
       READ(IUNIT) U1
       READ(IUNIT) V1
-      READ(IUNIT) DZDT
+      READ(IUNIT) !DZDT  closed by JungHoon/dzdt is from fort.36(below)
       READ(IUNIT) Z1
 !      READ(IUNIT) GLON,GLAT
       READ(IUNIT) HLON,HLAT,VLON,VLAT
@@ -203,23 +235,63 @@
 
       CLOSE(IUNIT)
 
-      IUNIT=30+ITIM    ! Original GFS initial data
+      IUNIT=30+ITIM    ! Original GFS initial data: modified by JungHoon
 
       READ(IUNIT)   ! NX,NY,NZ
       READ(IUNIT)   ! DLMD,DPHD,CENTRAL_LON,CENTRAL_LAT
-      READ(IUNIT)   ! PT,PDTOP
+      READ(IUNIT) PM4
       READ(IUNIT) T4
       READ(IUNIT) Q4
-      READ(IUNIT)
-      READ(IUNIT)
-      READ(IUNIT)
-      READ(IUNIT)
-      READ(IUNIT)
-      READ(IUNIT)
-      READ(IUNIT)
-      READ(IUNIT)
+      READ(IUNIT)   ! U1
+      READ(IUNIT)   ! V1
+      READ(IUNIT) DZDT
+      READ(IUNIT)   ! Z1
+      READ(IUNIT)   ! HLON,HLAT,VLON,VLAT
+      READ(IUNIT)   ! P1
+      READ(IUNIT)   ! PD           ! surface pressure
+      READ(IUNIT)   ! ETA1
+      READ(IUNIT)   ! ETA2
+      READ(IUNIT) !land
+      READ(IUNIT) !sfrc
+      READ(IUNIT) !C101
+      if(ivi_cloud.ge.1)then
+       READ(IUNIT) QC4
+       READ(IUNIT) QR4
+       READ(IUNIT) QI4
+       READ(IUNIT) QS4
+       READ(IUNIT) QG4
+       if(ivi_cloud.eq.2)then
+        print*,'Read GFS cloud ice and rain number concentrations'
+        READ(IUNIT) NCI4    ! GFS cloud ice water number concentration
+        READ(IUNIT) NCR4    ! GFS rain number concentration
+       endif
+      endif
 
       CLOSE(IUNIT)
+
+!=====================================
+      READ(61) !KSTM
+      READ(61) !HLAT2,HLON2
+      READ(61) !VLAT2,VLON2
+      READ(61) !PCST
+      READ(61) !HP
+      READ(61) !ST_NAME(KST)
+      READ(61) CLON_NEW,CLAT_NEW
+      write(*,*) 'GFS vortex center is...'
+      PRINT*,CLON_NEW,CLAT_NEW
+      distm=1.E20
+      do j=1,ny
+      do i=1,nx !* Search for indices nearest to center of storm
+         distt=(HLON(i,j)-CLON_NEW)**2+(HLAT(i,j)-CLAT_NEW)**2
+         if (distm.GT.distt) then
+            distm=distt
+            icst=i
+            jcst=j
+         end if
+      end do
+      end do
+      close(61)
+!=======================================
 
       ALLOCATE ( SLP1(NX,NY),RIJ(NX,NY) )
       ALLOCATE ( ZS1(NX,NY),TS1(NX,NY),QS1(NX,NY) )
@@ -998,6 +1070,108 @@
       ENDDO
       deallocate (work_1,work_2)
 
+!=====================================================================
+      if(ivi_cloud.ge.1)then
+      write(*,*) 'START interpolation from hybrid to pressure for GFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=1,NY
+        DO I=1,NX
+          CYC_14: DO K=1,KMX
+            IF(PCST(K).GE.PM4(I,J,1))THEN       ! Below PM4(I,J,1)
+              QCP(I,J,K)=QC4(I,J,1)
+              QRP(I,J,K)=QR4(I,J,1)
+              QSP(I,J,K)=QS4(I,J,1)
+              QGP(I,J,K)=QG4(I,J,1)
+              QIP(I,J,K)=QI4(I,J,1)
+              DZDTP(I,J,K)=DZDT(I,J,1)
+            ELSE IF(PCST(K).LE.PM4(I,J,NZ))THEN
+              QCP(I,J,K)=QC4(I,J,NZ)
+              QRP(I,J,K)=QR4(I,J,NZ)
+              QSP(I,J,K)=QS4(I,J,NZ)
+              QGP(I,J,K)=QG4(I,J,NZ)
+              QIP(I,J,K)=QI4(I,J,NZ)
+              DZDTP(I,J,K)=DZDT(I,J,NZ)
+            ELSE
+              DO N=1,NZ-1
+                IF(PCST(K).LE.PM4(I,J,N).and.PCST(K).GT.PM4(I,J,N+1))THEN
+                  W1=ALOG(1.*PM4(I,J,N+1))-ALOG(1.*PM4(I,J,N))
+                  W=(ALOG(1.*PCST(K))-ALOG(1.*PM4(I,J,N)))/W1
+                  QCP(I,J,K)=QC4(I,J,N)+(QC4(I,J,N+1)-QC4(I,J,N))*W
+                  QRP(I,J,K)=QR4(I,J,N)+(QR4(I,J,N+1)-QR4(I,J,N))*W
+                  QSP(I,J,K)=QS4(I,J,N)+(QS4(I,J,N+1)-QS4(I,J,N))*W
+                  QGP(I,J,K)=QG4(I,J,N)+(QG4(I,J,N+1)-QG4(I,J,N))*W
+                  QIP(I,J,K)=QI4(I,J,N)+(QI4(I,J,N+1)-QI4(I,J,N))*W
+                  DZDTP(I,J,K)=DZDT(I,J,N)+(DZDT(I,J,N+1)-DZDT(I,J,N))*W
+                  CYCLE CYC_14
+                END IF
+              END DO
+            END IF
+          END DO CYC_14
+        END DO
+      END DO
+
+!======= Same interpolation for two additional Thompson microphysics
+!variables
+      if(ivi_cloud.eq.2)then
+      print*,'Interpolation for two additional Thompson variables:GFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=1,NY
+        DO I=1,NX
+          CYC_24: DO K=1,KMX
+            IF(PCST(K).GE.PM4(I,J,1))THEN       ! Below PM4(I,J,1)
+              NCIP(I,J,K)=NCI4(I,J,1)
+              NCRP(I,J,K)=NCR4(I,J,1)
+            ELSE IF(PCST(K).LE.PM4(I,J,NZ))THEN
+              NCIP(I,J,K)=NCI4(I,J,NZ)
+              NCRP(I,J,K)=NCR4(I,J,NZ)
+            ELSE
+              DO N=1,NZ-1
+                IF(PCST(K).LE.PM4(I,J,N).and.PCST(K).GT.PM4(I,J,N+1))THEN
+                  W1=ALOG(1.*PM4(I,J,N+1))-ALOG(1.*PM4(I,J,N))
+                  W=(ALOG(1.*PCST(K))-ALOG(1.*PM4(I,J,N)))/W1
+                  NCIP(I,J,K)=NCI4(I,J,N)+(NCI4(I,J,N+1)-NCI4(I,J,N))*W
+                  NCRP(I,J,K)=NCR4(I,J,N)+(NCR4(I,J,N+1)-NCR4(I,J,N))*W
+                  CYCLE CYC_24
+                END IF
+              END DO
+            END IF
+          END DO CYC_24
+        END DO
+       END DO
+      endif ! Done for Thompson microphysics configuration
+
+      write(*,*) 'DONE interpolation from hybrid to pressure for GFS'
+!-------------------------------------------------------------------------
+
+      call findlev(qip,qcp,qrp,qsp,qgp,PCST,nx,ny,kmx,icst,jcst,irange,nk,  &
+      isnow,nice,meltlev,nqr,nqc,n100)
+      write(*,*) 'Starting the relocation of cloud fields below k=',nk
+      write(*,*) 'Model storm center is',HLON(icst,jcst),HLAT(icst,jcst)
+      write(*,*) 'Model storm center grids are ',icst,jcst
+      write(*,*) 'TCvital center is ',HLON(ictr,jctr),HLAT(ictr,jctr)
+      write(*,*) 'TCvital center grids are  ',ictr,jctr
+
+! Relocating cloud and vertical velocity of GFS
+       itag_c=0
+       call relocation(qrp,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qcp,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qsp,nx,ny,kmx,nd,meltlev,isnow,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qgp,nx,ny,kmx,nd,meltlev,isnow,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qip,nx,ny,kmx,nd,nice,nk,irange,ictr,jctr,icst,jcst,itag_c,10)
+       if(ivi_cloud.eq.2)then
+        call relocation(NCRP,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+        call relocation(NCIP,nx,ny,kmx,nd,nice,nk,irange,ictr,jctr,icst,jcst,itag_c,10)
+       endif
+       itag_w=0
+       call relocation(dzdtp,nx,ny,kmx,nw,1,n100,iwrange,ictr,jctr,icst,jcst,itag_w,5)
+       write(*,*) 'Complete the relocation of cloud & DZDT fields'
+
+      endif
+!-------------------------------------------------------------------------
+
+
 ! PD(I,J)=P1(I,J,1)-PDTOP-PT=PSFC(I,J)-PDTOP-PT
 !       DO K=1,NZ+1
 !       DO J=1,NY
@@ -1160,6 +1334,113 @@
 !      WRITE(64)((USCM(I,J),I=1,NX),J=1,NY,2)
 !      WRITE(64)((VSCM(I,J),I=1,NX),J=1,NY,2)
 
+!======================================================================
+      if(ivi_cloud.ge.1)then
+! Now, merged or relocated cloud & DZDT fields are changed back from
+! constant pressure level (PCST) to newly adjusted model pressure level(PMID1)
+! To save computational time, this is done only 900 by 900 with respect
+! to the TC center
+      write(*,*) 'START reverting from pressure to hybrid level!'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=jctr-450,jctr+450
+        DO I=ictr-450,ictr+450
+        nloop1: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PCST(1))THEN            ! Below PMID1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              QC4(I,J,N)=QCP(I,J,1)
+              QR4(I,J,N)=QRP(I,J,1)
+              QS4(I,J,N)=QSP(I,J,1)
+              QG4(I,J,N)=QGP(I,J,1)
+              QI4(I,J,N)=QIP(I,J,1)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT(I,J,N)=DZDTP(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PCST(KMX))THEN
+             if(itag_c(i,j).eq.1)then
+              QC4(I,J,N)=QCP(I,J,KMX)
+              QR4(I,J,N)=QRP(I,J,KMX)
+              QS4(I,J,N)=QSP(I,J,KMX)
+              QG4(I,J,N)=QGP(I,J,KMX)
+              QI4(I,J,N)=QIP(I,J,KMX)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT(I,J,N)=DZDTP(I,J,KMX)
+             endif
+            ELSE
+              DO K=1,KMX-1
+                IF(PMID1(I,J,N).LE.PCST(K).and.PMID1(I,J,N).GT.PCST(K+1))THEN
+                  W1=ALOG(1.*PCST(K+1))-ALOG(1.*PCST(K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PCST(K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   QC4(I,J,N)=QCP(I,J,K)+ &
+                           (QCP(I,J,K+1)-QCP(I,J,K))*W
+                   QR4(I,J,N)=QRP(I,J,K)+ &
+                           (QRP(I,J,K+1)-QRP(I,J,K))*W
+                   QS4(I,J,N)=QSP(I,J,K)+ &
+                           (QSP(I,J,K+1)-QSP(I,J,K))*W
+                   QG4(I,J,N)=QGP(I,J,K)+ &
+                           (QGP(I,J,K+1)-QGP(I,J,K))*W
+                   QI4(I,J,N)=QIP(I,J,K)+ &
+                           (QIP(I,J,K+1)-QIP(I,J,K))*W
+                  endif
+                  if(itag_w(i,j).eq.1)then
+                   DZDT(I,J,N)=DZDTP(I,J,K)+ &
+                           (DZDTP(I,J,K+1)-DZDTP(I,J,K))*W
+                  endif
+                  cycle nloop1
+                END IF
+              END DO
+            END IF
+          END DO nloop1
+        END DO
+      END DO
+
+!======= Same interpolation for two additional Thompson microphysics variables
+      if(ivi_cloud.eq.2)then
+      print*,'Interpolation for two additional Thompson variables: GFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=jctr-450,jctr+450
+        DO I=ictr-450,ictr+450
+        nloop2: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PCST(1))THEN            ! Below PMID1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              NCI4(I,J,N)=NCIP(I,J,1)
+              NCR4(I,J,N)=NCRP(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PCST(KMX))THEN
+             if(itag_c(i,j).eq.1)then
+              NCI4(I,J,N)=NCIP(I,J,KMX)
+              NCR4(I,J,N)=NCRP(I,J,KMX)
+             endif
+            ELSE
+              DO K=1,KMX-1
+                IF(PMID1(I,J,N).LE.PCST(K).and.PMID1(I,J,N).GT.PCST(K+1))THEN
+                  W1=ALOG(1.*PCST(K+1))-ALOG(1.*PCST(K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PCST(K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   NCI4(I,J,N)=NCIP(I,J,K)+ &
+                           (NCIP(I,J,K+1)-NCIP(I,J,K))*W
+                   NCR4(I,J,N)=NCRP(I,J,K)+ &
+                           (NCRP(I,J,K+1)-NCRP(I,J,K))*W
+                  endif
+                  cycle nloop2
+                END IF
+              END DO
+            END IF
+          END DO nloop2
+        END DO
+       END DO
+      endif
+!=========================================================================
+
+      write(*,*) 'DONE reverting from pressure to hybrid level!'
+      endif
+!---------------------------------------------------------------------
+!=================================================================
+
       IUNIT=50+ITIM
 
       WRITE(IUNIT) NX,NY,NZ,I360
@@ -1177,6 +1458,17 @@
       WRITE(IUNIT) PD1
       WRITE(IUNIT) ETA1
       WRITE(IUNIT) ETA2
+      if(ivi_cloud.ge.1)then
+       WRITE(IUNIT) QC4
+       WRITE(IUNIT) QR4
+       WRITE(IUNIT) QI4
+       WRITE(IUNIT) QS4
+       WRITE(IUNIT) QG4
+       if(ivi_cloud.eq.2)then
+        WRITE(IUNIT) NCI4
+        WRITE(IUNIT) NCR4
+       endif
+      endif
 
       CLOSE(IUNIT)
 
@@ -1356,4 +1648,164 @@ end subroutine dbend
 
       RETURN
       END
+
+!==============================================================================
+!=========================================================================
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine relocation(val,nx,ny,nz,nd,na,nb,irange,ictr,jctr,icst,jcst,itag,maxsmth)
+      implicit none
+      integer i,j,k,n,nx,ny,nz,nd,ictr,jctr,icst,jcst,irange,na,nb,maxsmth
+      real val(nx,ny,nz),tcval(nd,nd,nz),val_2d(nx,ny),val_save(nx,ny)
+      integer itag(nx,ny)
+      real dx,dy,range,dis,dis1,dis2
+      dx = 0.02
+      dy = 0.02
+      range = irange*dx
+
+      do k=na,nb
+
+       val_save(:,:)=val(:,:,k)
+      ! Get the GFS field from the "irange" grid points from the model
+      ! TC center
+       do i=icst-irange,icst+irange
+        do j=jcst-irange,jcst+irange
+         tcval(i-icst+irange+1,j-jcst+irange+1,k) = val(i,j,k)
+        enddo
+       enddo
+
+       do j=1,nd
+        do i=1,nd
+         dis = sqrt(((dx*(i-(nd+1)/2))**2+(dy*(j-(nd+1)/2))**2))
+         if(dis.ge.range) tcval(i,j,k) = 0.0
+        enddo
+       enddo
+      ! Get the GFS field from the "irange" grid points from the model TC center
+      ! REPLACE cloud and W fields with the above extracted field within the
+      ! certain radius (6 dgrees for cloud, 3 degree for DZDT) from
+      ! TCvital location (ictr,jctr)
+       do i=ictr-irange,ictr+irange
+        do j=jctr-irange,jctr+irange
+         if( sqrt(((dx*(i-ictr))**2)+((dy*(j-jctr))**2)) .lt. range )then
+          val(i,j,k)=tcval(i-ictr+irange+1,j-jctr+irange+1,k)
+         endif
+        enddo
+       enddo
+
+       ! Do some smoothing on the boundary of modified region
+       ! When there is no relocation in the cold start, smoothing will
+       ! be skipped
+       if( icst.ne.ictr .or. jcst.ne.jctr)then
+        do n=1,maxsmth
+         val_2d(:,:)=val(:,:,k)
+         call smooth(val_2d,nx,ny,ictr,jctr,range,dx,dy)
+         val(:,:,k)=val_2d(:,:)
+        enddo
+       endif
+
+       ! itag(i,j) = 1 indicates where the cloud or W are modified
+       do j=1,ny
+        do i=1,nx
+         dis1 = sqrt(((dx*(i-icst))**2+(dy*(j-jcst))**2))
+         if( dis1.le.(range+0.5) ) itag(i,j) = 1
+         dis2 = sqrt(((dx*(i-ictr))**2+(dy*(j-jctr))**2))
+         if( dis2.le.(range+0.5) ) itag(i,j) = 1
+        enddo
+       enddo
+
+      enddo
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!====================================================================================
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine smooth(val,nx,ny,icen,jcen,range,dx,dy)
+      implicit none
+      integer i,j,nx,ny,icen,jcen
+      real val(nx,ny),val_tmp(nx,ny)
+      real dx,dy,range,dis
+
+      val_tmp=val
+!$omp parallel do &
+!$omp& private(i,j,dis)
+      do j=1,ny
+       do i=1,nx
+        dis = sqrt(((dx*(i-icen))**2+(dy*(j-jcen))**2))
+        if( dis.le.(range+0.5) .and. dis.ge.(range-0.5) )then
+         val(i,j)=     &
+         ( val_tmp(i,j-1)+val_tmp(i+1,j-1)+val_tmp(i-1,j-1)+   &
+           val_tmp(i,j) + val_tmp(i+1,j) + val_tmp(i-1,j)+     &
+           val_tmp(i,j+1)+val_tmp(i+1,j+1)+val_tmp(i-1,j+1) )/9.
+        endif
+       enddo
+      enddo
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine findlev(qi,qc,qr,qs,qg,PCST,nx,ny,nz,icst,jcst,irange, &
+      nk,isnow,nice,meltlev,nqr,nqc,n100)
+      implicit none
+      integer i,j,k,nx,ny,nz,icst,jcst,irange,nk,nice,meltlev,nqr,nqc,n100,isnow
+      real deltp1,deltp
+      real qi(nx,ny,nz),qc(nx,ny,nz),qr(nx,ny,nz),qs(nx,ny,nz),qg(nx,ny,nz)
+      real PCST(nz)
+
+      do k=nz,1,-1
+       if(maxval(QI(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         nk=k
+         write(*,*) 'ICE TOP lev=',k
+         exit
+       endif
+      enddo
+      do k=1,nz
+       if(maxval(QI(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         write(*,*) 'ICE BOTTOM lev=',k
+         nice=k
+         exit
+       endif
+      enddo
+      do k=nz,1,-1
+       if(maxval(QS(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         write(*,*) 'SNOW TOP lev=',k
+         isnow=k
+         exit
+       endif
+      enddo
+      do k=1,nz
+       if(maxval(QG(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         write(*,*) 'GRAUPAL BOTTOM lev=',k
+         meltlev=k
+         exit
+       endif
+      enddo
+      !do k=1,nz
+      ! if(maxval(QR(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+      !   write(*,*) 'RAIN WATER BOTTOM lev=',k
+      !   nqr=k
+      !   exit
+      ! endif
+      !enddo
+      nqr=1 ! for RAIN WATER BOTTOM lev, we can set as 1
+      do k=nz,1,-1
+       if(maxval(QC(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         nqc=k
+         write(*,*) 'CLOUD TOP lev=',k
+         exit
+       endif
+      enddo
+      deltp=1.e20
+      do k=nz,1,-1
+         deltp1=abs(PCST(k)-10000.)
+         if (deltp1.lt.deltp) then
+            deltp=deltp1
+            n100=k
+         endif
+      enddo
+      write(*,*) '100-hPa lev for vertical velocity change= ',n100,' ',PCST(n100)
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/sorc/hafs_tools.fd/sorc/hafs_vi/anl_combine/anl_combine.f90
+++ b/sorc/hafs_tools.fd/sorc/hafs_vi/anl_combine/anl_combine.f90
@@ -12,6 +12,20 @@
 !                  Added option (INITOPT) to do relcation only or to do full
 !                  vortex initialization. Modified to allow vortex
 !                  initialization at other time levels
+! REVISED  AUTHOR: JungHoon Shin Feb 2023 NCEP/EMC
+!                  VI is upgraded A LOT so that cloud fields and vertical
+!                  velocity can be relocated on GFS (IGFS_FLAG: 0) or
+!                  cycled from previous HAFS 6-h forecast (IGFS_FLAG: 6)
+!                  For this new VI, split.f90, anl_combine.f90,
+!                  anl_enhance.f90 need to be change. We don't need to
+!                  change anl_pert.f90 (I already confirmed)
+! REVISED  AUTHOR: JungHoon Shin July 2023 NCEP/EMC
+!                  The code is updated further with one more input
+!                  argument (ivi_cloud) so that cloud modification can be on (1 or 2) or off (0).
+!                  0: No cloud changes in VI, 1: GFDL microphysics, 2:Thompson microphysics
+!                  This change requires changes in exhafs_atm_vi.sh
+!                  Now input arguement is like this:
+!  ./hafs_vi_anl_combine.x ${gesfhr} ${pubbasin2} ${gfs_flag} ${initopt} ${vi_cloud}
 !______________________________________________________________________________
 
 ! DECLARE VARIABLES
@@ -23,6 +37,7 @@
       integer ICLAT,ICLON,Ipsfc,Ipcls,Irmax,ivobs,Ir_vobs
       integer NCHT,KSTM,k850,KST,IWMIN1,IWMAX1,JWMIN1,JWMAX1,KNHC,MNHC
       integer IC1,JC1,MDX,MDY,NXT,NYT,NXT1,NYT1
+      integer nd,irange,nw,iwrange,nk,meltlev,nqc,nice,nqr,isnow,n100
       integer ictr,jctr,i_max,j_max,IMV,JMV,IR1,IR,K1,IR_1,id_storm
       integer IDAT,IHOUR,IFH,LAT,LON,IVFT,IPFT,IV34,IMAX1,JMAX1
       integer iparam,icst,jcst,ID_INDX,JD_INDX,imn1,imx1,jmn1,jmx1
@@ -58,6 +73,18 @@
       REAL(4) LON1,LAT1,LON2,LAT2
 
       REAL(4), ALLOCATABLE :: T1(:,:,:),Q1(:,:,:)
+      REAL(4), ALLOCATABLE :: QC(:,:,:),QR(:,:,:),QS(:,:,:)      !GFS cloud on hybrid level
+      REAL(4), ALLOCATABLE :: QI(:,:,:),QG(:,:,:)                !GFS cloud on hybrid level
+      REAL(4), ALLOCATABLE :: NCI(:,:,:),NCR(:,:,:)              !GFS cloud concentration on hybrid level
+      REAL(4), ALLOCATABLE :: QCP(:,:,:),QRP(:,:,:),QSP(:,:,:)   !GFS cloud on P level
+      REAL(4), ALLOCATABLE :: QIP(:,:,:),QGP(:,:,:),DZDTP(:,:,:) !GFS cloud & W on P level
+      REAL(4), ALLOCATABLE :: NCIP(:,:,:),NCRP(:,:,:)            !GFS cloud concentration on P level
+      REAL(4), ALLOCATABLE :: QC2(:,:,:),QR2(:,:,:),QS2(:,:,:)   !HAFS cloud on hybrid level
+      REAL(4), ALLOCATABLE :: QI2(:,:,:),QG2(:,:,:),DZDT2(:,:,:) !HAFS cloud & W on hybrid level
+      REAL(4), ALLOCATABLE :: NCI2(:,:,:),NCR2(:,:,:)            !HAFS cloud concentration on hybrid level
+      REAL(4), ALLOCATABLE :: QCP2(:,:,:),QRP2(:,:,:),QSP2(:,:,:) !HAFS cloud on P level
+      REAL(4), ALLOCATABLE :: QIP2(:,:,:),QGP2(:,:,:),DZDTP2(:,:,:) !HAFS cloud & W on P level
+      REAL(4), ALLOCATABLE :: NCIP2(:,:,:),NCRP2(:,:,:)          !HAFS cloud concentration on P level
       REAL(4), ALLOCATABLE :: U1(:,:,:),V1(:,:,:),DZDT(:,:,:)
       REAL(4), ALLOCATABLE :: Z1(:,:,:),P1(:,:,:)
       REAL(4), ALLOCATABLE :: GLON(:,:),GLAT(:,:)
@@ -86,7 +113,7 @@
 ! working array
 
       REAL(4), ALLOCATABLE :: SLP1(:,:),ANG2(:,:)
-      REAL(4), ALLOCATABLE :: PMID1(:,:,:),ZMID1(:,:,:)
+      REAL(4), ALLOCATABLE :: PMID1(:,:,:),ZMID1(:,:,:),PMID2(:,:,:) !PMID2: pressure from HAFS
       REAL(4), ALLOCATABLE :: ZS1(:,:),TS1(:,:),QS1(:,:)
 
       REAL(4), ALLOCATABLE :: U_S(:,:),U_A(:,:)
@@ -130,6 +157,8 @@
 
       REAL(4), ALLOCATABLE :: dist(:,:)
 
+      integer(4), ALLOCATABLE :: itag_c(:,:),itag_w(:,:) ! Tag array for cloud & W relocation
+
       integer(4) IH1(4),JH1(4),IV1(4),JV1(4),MLAT(7),MLON(7)
 
       CHARACTER ST_NAME(NST)*3,SN*1,EW*1,DEPTH*1
@@ -147,6 +176,8 @@
       CHARACTER PART1*2,basin*2,NUM*2
 !zhang: added basin domain shift option
       CHARACTER*2 :: basin1
+!shin: cloud modification option
+      integer :: ivi_cloud
       LOGICAL TSTH
       REAL :: check_west, check_east
 
@@ -156,6 +187,10 @@
 
       GRD=G/Rd
       rdgas1=287.04/9.80
+      irange = 300        !For cloud relocation
+      nd = 2*irange+1     !For cloud relocation
+      iwrange = 150        !For vertical velocity relocation
+      nw = 2*iwrange+1     !For vertical velocity relocation
 
       pi=4.*atan(1.)
       pi_deg=180./pi     !* rad -> deg
@@ -178,9 +213,12 @@
       deg2km= deg2rad*6.371E3 !* deg -> km
       deg2m = deg2rad*6.371E6 !* deg ->  m
 
-      READ(5,*)ITIM,basin1,IGFS_FLAG,INITOPT
+      READ(5,*)ITIM,basin1,IGFS_FLAG,INITOPT,ivi_cloud
 
       print*,'ITIM,basin1,IGFS_FLAG,INITOPT=',ITIM,basin1,IGFS_FLAG,INITOPT
+      if(ivi_cloud.eq.0) write(*,*) 'Cloud modification is OFF!!'
+      if(ivi_cloud.eq.1) write(*,*) 'Cloud change is ON (GFDL)!!'
+      if(ivi_cloud.eq.2) write(*,*) 'Cloud change is ON (Thompson)!!'
 
 ! Read TC vitals ...
 
@@ -258,8 +296,14 @@
       ALLOCATE ( HLON(NX,NY),HLAT(NX,NY) )
       ALLOCATE ( VLON(NX,NY),VLAT(NX,NY) )
       ALLOCATE ( PMID1(NX,NY,NZ),ZMID1(NX,NY,NZ) )
+      ALLOCATE ( QC(NX,NY,NZ),QR(NX,NY,NZ),QI(NX,NY,NZ) )
+      ALLOCATE ( QS(NX,NY,NZ),QG(NX,NY,NZ) )
+      ALLOCATE ( NCI(NX,NY,NZ),NCR(NX,NY,NZ) )
+      ALLOCATE ( QCP(NX,NY,KMX),QRP(NX,NY,KMX),QIP(NX,NY,KMX) )
+      ALLOCATE ( QSP(NX,NY,KMX),QGP(NX,NY,KMX),DZDTP(NX,NY,KMX) )
+      ALLOCATE ( NCIP(NX,NY,KMX),NCRP(NX,NY,KMX) )
 
-      ALLOCATE ( dist(NX,NY) )
+      ALLOCATE ( dist(NX,NY), itag_c(NX,NY), itag_w(NX,NY) )
 
       READ(IUNIT) LON1,LAT1,LON2,LAT2,CENTRAL_LON,CENTRAL_LAT ! Domain res & center (deg)
       READ(IUNIT) PMID1
@@ -275,6 +319,20 @@
       READ(IUNIT) PD1
       READ(IUNIT) ETA1
       READ(IUNIT) ETA2
+      READ(IUNIT) !USCM
+      READ(IUNIT) !VSCM
+      if(ivi_cloud.ge.1)then
+       READ(IUNIT) QC     ! cloud from GFS
+       READ(IUNIT) QR     ! rain from GFS
+       READ(IUNIT) QI     ! ice from GFS
+       READ(IUNIT) QS     ! snow from GFS
+       READ(IUNIT) QG     ! graupel from GFS
+       if(ivi_cloud.eq.2)then
+        print*,'Read GFS cloud ice and rain number concentrations'
+        READ(IUNIT) NCI    ! GFS cloud ice water number concentration
+        READ(IUNIT) NCR    ! GFS rain number concentration
+       endif
+      endif
 !      READ(IUNIT) USCM
 !      READ(IUNIT) VSCM
 
@@ -356,7 +414,14 @@
       READ(IUNIT) JX,JY
 
       ALLOCATE ( A101(JX,JY),B101(JX,JY),C101(JX,JY) )
+      ALLOCATE ( DZDT2(JX,JY,NZ),QC2(JX,JY,NZ),QR2(JX,JY,NZ) )
+      ALLOCATE ( QI2(JX,JY,NZ),QS2(JX,JY,NZ),QG2(JX,JY,NZ),PMID2(JX,JY,NZ) )
+      ALLOCATE ( NCI2(JX,JY,NZ),NCR2(JX,JY,NZ) )
+      ALLOCATE ( QCP2(JX,JY,KMX),QRP2(JX,JY,KMX),QIP2(JX,JY,KMX) )
+      ALLOCATE ( QSP2(JX,JY,KMX),QGP2(JX,JY,KMX),DZDTP2(JX,JY,KMX) )
+      ALLOCATE ( NCIP2(JX,JY,KMX),NCRP2(JX,JY,KMX) )
 
+      IF(IGFS_FLAG.EQ.0)THEN ! TC is not cycled from HAFS
       READ(IUNIT) !LON1,LAT1,LON2,LAT2,CENTRAL_LON,CENTRAL_LAT
       READ(IUNIT) !PM1
       READ(IUNIT) !T1
@@ -375,7 +440,47 @@
       READ(IUNIT) C101
 
       CLOSE(IUNIT)
+      ENDIF
 
+
+      IF(IGFS_FLAG.EQ.6)THEN ! TC is cycled from HAFS. Cloud & W are required
+      READ(IUNIT) !LON1,LAT1,LON2,LAT2,CENTRAL_LON,CENTRAL_LAT
+      READ(IUNIT) PMID2     ! pressure values from HAFS forecast
+      READ(IUNIT) !T1
+      READ(IUNIT) !Q1
+      READ(IUNIT) !U1
+      READ(IUNIT) !V1
+      READ(IUNIT) DZDT2    ! vertical velocity from HAFS forecast
+      READ(IUNIT) !Z1
+      READ(IUNIT) !HLON,HLAT,VLON,VLAT
+      READ(IUNIT) !P1
+      READ(IUNIT) !PD           ! surface pressure
+      READ(IUNIT) !ETA1
+      READ(IUNIT) !ETA2
+      READ(IUNIT) A101
+      READ(IUNIT) B101
+      READ(IUNIT) C101
+
+      if(ivi_cloud.ge.1)then
+       READ(IUNIT) QC2     ! cloud from HAFS forecast
+       READ(IUNIT) QR2     ! rain from HAFS forecast
+       READ(IUNIT) QI2     ! ice from HAFS forecast
+       READ(IUNIT) QS2     ! snow from HAFS forecast
+       READ(IUNIT) QG2     ! graupel from HAFS forecast
+       if(ivi_cloud.eq.2)then
+        print*,'Read HAFS cloud ice and rain number concentrations'
+        READ(IUNIT) NCI2   ! cloud ice water number concentration from HAFS
+        READ(IUNIT) NCR2   ! rain number concentration from HAFS
+       endif
+      endif
+
+      CLOSE(IUNIT)
+      ENDIF
+
+      IF(IGFS_FLAG.NE.0 .and. IGFS_FLAG.NE.6)THEN
+       write(*,*) 'IGFS_FLAG should be 0 or 6, but it is ',IGFS_FLAG
+       stop
+      ENDIF
       PRINT*,'JX,JY,NX,NY=',JX,JY,NX,NY
 
 ! finsih compute 10m wind
@@ -1397,7 +1502,7 @@
       ENDDO
       ENDDO
 
-      PRINT*, '2-parameter storm-size correction reduced to 1 parameter.'
+      PRINT*, '2-parameter storm-size correction reduced to 1 parameter'
 
       else  !* - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
@@ -1638,6 +1743,246 @@
          TWMAX=TWMAX
       end if
 
+
+!---------------------- START of cloud modification --------------------
+      if(ivi_cloud.ge.1)then
+! NOTE: Cloud and vertical velocity relocation or cycling is done before
+! whether this code decides whether the vortex is enhanced by bogus vortex or not.
+! Because cloud & vertical velocity relocation or cycling are not
+! affected by enhanced process, we can complete relocation or cycling in
+! here, which makes the code simpler.
+! Reverting the final cloud and W fields from pressure level to hybrid level
+! will be done after the model pressure level (PMID1) is adjusted
+
+!     open(777,file='cloud-before.dat',form='unformatted',recl=nx*ny*4)
+!     DO K=1,NZ
+!        WRITE(777)((QC(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(777)((QR(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(777)((QI(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(777)((QS(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(777)((QG(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(777)((DZDT(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+
+      write(*,*) 'START interpolation from hybrid to pressure for GFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=1,NY
+        DO I=1,NX
+          CYC_14: DO K=1,KMX
+            IF(PCST(K).GE.PMID1(I,J,1))THEN            ! Below PMID1(I,J,1)
+              QCP(I,J,K)=QC(I,J,1)
+              QRP(I,J,K)=QR(I,J,1)
+              QSP(I,J,K)=QS(I,J,1)
+              QGP(I,J,K)=QG(I,J,1)
+              QIP(I,J,K)=QI(I,J,1)
+              DZDTP(I,J,K)=DZDT(I,J,1)
+            ELSE IF(PCST(K).LE.PMID1(I,J,NZ))THEN
+              QCP(I,J,K)=QC(I,J,NZ)
+              QRP(I,J,K)=QR(I,J,NZ)
+              QSP(I,J,K)=QS(I,J,NZ)
+              QGP(I,J,K)=QG(I,J,NZ)
+              QIP(I,J,K)=QI(I,J,NZ)
+              DZDTP(I,J,K)=DZDT(I,J,NZ)
+            ELSE
+              DO N=1,NZ-1
+                IF(PCST(K).LE.PMID1(I,J,N).and.PCST(K).GT.PMID1(I,J,N+1))THEN
+                  W1=ALOG(1.*PMID1(I,J,N+1))-ALOG(1.*PMID1(I,J,N))
+                  W=(ALOG(1.*PCST(K))-ALOG(1.*PMID1(I,J,N)))/W1
+                  QCP(I,J,K)=QC(I,J,N)+(QC(I,J,N+1)-QC(I,J,N))*W
+                  QRP(I,J,K)=QR(I,J,N)+(QR(I,J,N+1)-QR(I,J,N))*W
+                  QSP(I,J,K)=QS(I,J,N)+(QS(I,J,N+1)-QS(I,J,N))*W
+                  QGP(I,J,K)=QG(I,J,N)+(QG(I,J,N+1)-QG(I,J,N))*W
+                  QIP(I,J,K)=QI(I,J,N)+(QI(I,J,N+1)-QI(I,J,N))*W
+                  DZDTP(I,J,K)=DZDT(I,J,N)+(DZDT(I,J,N+1)-DZDT(I,J,N))*W
+                  CYCLE CYC_14
+                END IF
+              END DO
+            END IF
+          END DO CYC_14
+        END DO
+      END DO
+
+!======= Same interpolation for two additional Thompson microphysics variables
+      if(ivi_cloud.eq.2)then
+      print*,'Interpolation for two additional Thompson variables: GFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=1,NY
+        DO I=1,NX
+          CYC_24: DO K=1,KMX
+            IF(PCST(K).GE.PMID1(I,J,1))THEN            ! Below PMID1(I,J,1)
+              NCIP(I,J,K)=NCI(I,J,1)
+              NCRP(I,J,K)=NCR(I,J,1)
+            ELSE IF(PCST(K).LE.PMID1(I,J,NZ))THEN
+              NCIP(I,J,K)=NCI(I,J,NZ)
+              NCRP(I,J,K)=NCR(I,J,NZ)
+            ELSE
+              DO N=1,NZ-1
+                IF(PCST(K).LE.PMID1(I,J,N).and.PCST(K).GT.PMID1(I,J,N+1))THEN
+                  W1=ALOG(1.*PMID1(I,J,N+1))-ALOG(1.*PMID1(I,J,N))
+                  W=(ALOG(1.*PCST(K))-ALOG(1.*PMID1(I,J,N)))/W1
+                  NCIP(I,J,K)=NCI(I,J,N)+(NCI(I,J,N+1)-NCI(I,J,N))*W
+                  NCRP(I,J,K)=NCR(I,J,N)+(NCR(I,J,N+1)-NCR(I,J,N))*W
+                  CYCLE CYC_24
+                END IF
+              END DO
+            END IF
+          END DO CYC_24
+        END DO
+       END DO
+      endif ! Done for Thompson microphysics configuration
+!=========================================================================
+      write(*,*) 'DONE interpolation from hybrid to pressure for GFS'
+!-------------------------------------------------------------------------
+
+      call findlev(qip,qcp,qrp,qsp,qgp,PCST,nx,ny,kmx,icst,jcst,irange,nk,  &
+      isnow,nice,meltlev,nqr,nqc,n100)
+      write(*,*) 'Starting the relocation of cloud fields below k=',nk
+      write(*,*) 'Model storm center is ',HLON(icst,jcst),HLAT(icst,jcst)
+      write(*,*) 'Model storm center grids are ',icst,jcst
+      write(*,*) 'TCvital center is ',HLON(ictr,jctr),HLAT(ictr,jctr)
+      write(*,*) 'TCvital center grids are  ',ictr,jctr
+
+! Relocating cloud and vertical velocity of GFS
+      IF(IGFS_FLAG.EQ.0)THEN
+       itag_c=0
+       call relocation(qrp,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qcp,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qsp,nx,ny,kmx,nd,meltlev,isnow,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qgp,nx,ny,kmx,nd,meltlev,isnow,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation(qip,nx,ny,kmx,nd,nice,nk,irange,ictr,jctr,icst,jcst,itag_c,10)
+       if(ivi_cloud.eq.2)then
+        call relocation(NCRP,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+        call relocation(NCIP,nx,ny,kmx,nd,nice,nk,irange,ictr,jctr,icst,jcst,itag_c,10)
+       endif
+       itag_w=0
+       call relocation(dzdtp,nx,ny,kmx,nw,1,n100,iwrange,ictr,jctr,icst,jcst,itag_w,5)
+       write(*,*) 'Complete the relocation of cloud & DZDT fields'
+      ENDIF
+
+!++++++++++++++++++++++ Cycling the cloud from HAFS forecast +++++++++++++
+      IF(IGFS_FLAG.EQ.6)THEN
+
+      write(*,*) 'START interpolation from hybrid to pressure for HAFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=1,NY
+        DO I=1,NX
+          CYC_15: DO K=1,KMX
+            IF(PCST(K).GE.PMID2(I,J,1))THEN            ! Below PMID2(I,J,1)
+              QCP2(I,J,K)=QC2(I,J,1)
+              QRP2(I,J,K)=QR2(I,J,1)
+              QSP2(I,J,K)=QS2(I,J,1)
+              QGP2(I,J,K)=QG2(I,J,1)
+              QIP2(I,J,K)=QI2(I,J,1)
+              DZDTP2(I,J,K)=DZDT2(I,J,1)
+            ELSE IF(PCST(K).LE.PMID2(I,J,NZ))THEN
+              QCP2(I,J,K)=QC2(I,J,NZ)
+              QRP2(I,J,K)=QR2(I,J,NZ)
+              QSP2(I,J,K)=QS2(I,J,NZ)
+              QGP2(I,J,K)=QG2(I,J,NZ)
+              QIP2(I,J,K)=QI2(I,J,NZ)
+              DZDTP2(I,J,K)=DZDT2(I,J,NZ)
+            ELSE
+              DO N=1,NZ-1
+                IF(PCST(K).LE.PMID2(I,J,N).and.PCST(K).GT.PMID2(I,J,N+1))THEN
+                  W1=ALOG(1.*PMID2(I,J,N+1))-ALOG(1.*PMID2(I,J,N))
+                  W=(ALOG(1.*PCST(K))-ALOG(1.*PMID2(I,J,N)))/W1
+                  QCP2(I,J,K)=QC2(I,J,N)+(QC2(I,J,N+1)-QC2(I,J,N))*W
+                  QRP2(I,J,K)=QR2(I,J,N)+(QR2(I,J,N+1)-QR2(I,J,N))*W
+                  QSP2(I,J,K)=QS2(I,J,N)+(QS2(I,J,N+1)-QS2(I,J,N))*W
+                  QGP2(I,J,K)=QG2(I,J,N)+(QG2(I,J,N+1)-QG2(I,J,N))*W
+                  QIP2(I,J,K)=QI2(I,J,N)+(QI2(I,J,N+1)-QI2(I,J,N))*W
+                  DZDTP2(I,J,K)=DZDT2(I,J,N)+(DZDT2(I,J,N+1)-DZDT2(I,J,N))*W
+                  CYCLE CYC_15
+                END IF
+              END DO
+            END IF
+          END DO CYC_15
+        END DO
+      END DO
+
+!====== Same interpolation for two additional Thompson microphysics variables
+      if(ivi_cloud.eq.2)then
+      print*,'Interpolation for two additional Thompson variables: HAFS'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=1,NY
+        DO I=1,NX
+          CYC_25: DO K=1,KMX
+            IF(PCST(K).GE.PMID2(I,J,1))THEN            ! Below PMID2(I,J,1)
+              NCIP2(I,J,K)=NCI2(I,J,1)
+              NCRP2(I,J,K)=NCR2(I,J,1)
+            ELSE IF(PCST(K).LE.PMID2(I,J,NZ))THEN
+              NCIP2(I,J,K)=NCI2(I,J,NZ)
+              NCRP2(I,J,K)=NCR2(I,J,NZ)
+            ELSE
+              DO N=1,NZ-1
+                IF(PCST(K).LE.PMID2(I,J,N).and.PCST(K).GT.PMID2(I,J,N+1))THEN
+                  W1=ALOG(1.*PMID2(I,J,N+1))-ALOG(1.*PMID2(I,J,N))
+                  W=(ALOG(1.*PCST(K))-ALOG(1.*PMID2(I,J,N)))/W1
+                  NCIP2(I,J,K)=NCI2(I,J,N)+(NCI2(I,J,N+1)-NCI2(I,J,N))*W
+                  NCRP2(I,J,K)=NCR2(I,J,N)+(NCR2(I,J,N+1)-NCR2(I,J,N))*W
+                  CYCLE CYC_25
+                END IF
+              END DO
+            END IF
+          END DO CYC_25
+        END DO
+       END DO
+      endif ! Done for Thompson microphysics configuration
+!===============================================================
+
+      write(*,*) 'DONE interpolation from hybrid to pressure for HAFS'
+
+! Merge cloud and vertical velocity of HAFS to GFS background
+       itag_c=0
+       call relocation_hafs(qrp,qrp2,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation_hafs(qcp,qcp2,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation_hafs(qsp,qsp2,nx,ny,kmx,nd,meltlev,isnow,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation_hafs(qgp,qgp2,nx,ny,kmx,nd,meltlev,isnow,irange,ictr,jctr,icst,jcst,itag_c,5)
+       call relocation_hafs(qip,qip2,nx,ny,kmx,nd,nice,nk,irange,ictr,jctr,icst,jcst,itag_c,10)
+       if(ivi_cloud.eq.2)then
+        call relocation_hafs(NCRP,NCRP2,nx,ny,kmx,nd,nqr,nqc,irange,ictr,jctr,icst,jcst,itag_c,5)
+        call relocation_hafs(NCIP,NCIP2,nx,ny,kmx,nd,nice,nk,irange,ictr,jctr,icst,jcst,itag_c,10)
+       endif
+       itag_w=0
+       call relocation_hafs(dzdtp,dzdtp2,nx,ny,kmx,nw,1,n100,iwrange,ictr,jctr,icst,jcst,itag_w,5)
+       write(*,*) 'Complete the relocation/cycling of cloud&DZDT fields'
+      ENDIF
+
+!++++++++++++++++ End of Cycling the cloud from HAFS forecast +++++++++++++++++++++++
+
+!     open(778,file='cloud-121lev.dat',form='unformatted',recl=nx*ny*4)
+!     DO K=1,kmx
+!        WRITE(778)((QCP(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,kmx
+!        WRITE(778)((QRP(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,kmx
+!        WRITE(778)((QIP(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,kmx
+!        WRITE(778)((QSP(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!     DO K=1,kmx
+!        WRITE(778)((QGP(I,J,K),I=1,NX),J=1,NY)
+!     END DO
+!---------------------------------------------------------------------
+      endif
+!---------------------- END of cloud modification --------------------
    IF ( vs_t .LT. vobs .and. INITOPT .EQ. 0 ) THEN !* -------------------------------------------->
 
       IFLAG=1
@@ -1930,6 +2275,111 @@
       END DO
       END DO
 
+!-------------------------------------------------------------------------
+      if(ivi_cloud.ge.1)then
+! Now, merged or relocated cloud & DZDT fields are changed back from
+! constant pressure level (PCST) to newly adjusted model pressure level(PMID1)
+! To save computational time, this is done only 900 by 900 with respect
+! to the TC center
+      write(*,*) 'START reverting from pressure to hybrid level!'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=jctr-450,jctr+450
+        DO I=ictr-450,ictr+450
+        nloop1: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PCST(1))THEN            ! Below PMID1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              QC(I,J,N)=QCP(I,J,1)
+              QR(I,J,N)=QRP(I,J,1)
+              QS(I,J,N)=QSP(I,J,1)
+              QG(I,J,N)=QGP(I,J,1)
+              QI(I,J,N)=QIP(I,J,1)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT(I,J,N)=DZDTP(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PCST(KMX))THEN
+             if(itag_c(i,j).eq.1)then
+              QC(I,J,N)=QCP(I,J,KMX)
+              QR(I,J,N)=QRP(I,J,KMX)
+              QS(I,J,N)=QSP(I,J,KMX)
+              QG(I,J,N)=QGP(I,J,KMX)
+              QI(I,J,N)=QIP(I,J,KMX)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT(I,J,N)=DZDTP(I,J,KMX)
+             endif
+            ELSE
+              DO K=1,KMX-1
+                IF(PMID1(I,J,N).LE.PCST(K).and.PMID1(I,J,N).GT.PCST(K+1))THEN
+                  W1=ALOG(1.*PCST(K+1))-ALOG(1.*PCST(K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PCST(K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   QC(I,J,N)=QCP(I,J,K)+ &
+                           (QCP(I,J,K+1)-QCP(I,J,K))*W
+                   QR(I,J,N)=QRP(I,J,K)+ &
+                           (QRP(I,J,K+1)-QRP(I,J,K))*W
+                   QS(I,J,N)=QSP(I,J,K)+ &
+                           (QSP(I,J,K+1)-QSP(I,J,K))*W
+                   QG(I,J,N)=QGP(I,J,K)+ &
+                           (QGP(I,J,K+1)-QGP(I,J,K))*W
+                   QI(I,J,N)=QIP(I,J,K)+ &
+                           (QIP(I,J,K+1)-QIP(I,J,K))*W
+                  endif
+                  if(itag_w(i,j).eq.1)then
+                   DZDT(I,J,N)=DZDTP(I,J,K)+ &
+                           (DZDTP(I,J,K+1)-DZDTP(I,J,K))*W
+                  endif
+                  cycle nloop1
+                END IF
+              END DO
+            END IF
+          END DO nloop1
+        END DO
+      END DO
+
+!================= Same interpolcaton for Thompson microphysics =========
+      if(ivi_cloud.eq.2)then
+      print*,'Interpolation for two additional Thompson variables:FINAL'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=jctr-450,jctr+450
+        DO I=ictr-450,ictr+450
+        nloop2: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PCST(1))THEN            ! Below PMID1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              NCI(I,J,N)=NCIP(I,J,1)
+              NCR(I,J,N)=NCRP(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PCST(KMX))THEN
+             if(itag_c(i,j).eq.1)then
+              NCI(I,J,N)=NCIP(I,J,KMX)
+              NCR(I,J,N)=NCRP(I,J,KMX)
+             endif
+            ELSE
+              DO K=1,KMX-1
+                IF(PMID1(I,J,N).LE.PCST(K).and.PMID1(I,J,N).GT.PCST(K+1))THEN
+                  W1=ALOG(1.*PCST(K+1))-ALOG(1.*PCST(K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PCST(K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   NCI(I,J,N)=NCIP(I,J,K)+ &
+                           (NCIP(I,J,K+1)-NCIP(I,J,K))*W
+                   NCR(I,J,N)=NCRP(I,J,K)+ &
+                           (NCRP(I,J,K+1)-NCRP(I,J,K))*W
+                  endif
+                  cycle nloop2
+                END IF
+              END DO
+            END IF
+          END DO nloop2
+        END DO
+       END DO
+      endif
+!=============== Done for Thompson microphysics configuration ===============
+      write(*,*) 'DONE reverting from pressure to hybrid level!'
+      endif
+!---------------------------------------------------------------------
+
 ! WRITE 4x area env. data HWRF
 
       IUNIT=36
@@ -1952,6 +2402,17 @@
       WRITE(IUNIT) ETA2
       WRITE(IUNIT) USCM    ! no longer use
       WRITE(IUNIT) VSCM
+      if(ivi_cloud.ge.1)then
+       WRITE(IUNIT) QC
+       WRITE(IUNIT) QR
+       WRITE(IUNIT) QI
+       WRITE(IUNIT) QS
+       WRITE(IUNIT) QG
+       if(ivi_cloud.eq.2)then
+        WRITE(IUNIT) NCI
+        WRITE(IUNIT) NCR
+       endif
+      endif
 
       CLOSE(IUNIT)
 
@@ -1959,25 +2420,26 @@
 
       print*,'PDTOP,PT=',PDTOP,PT
 
-     WRITE(63)((SLP1(I,J),I=1,NX),J=1,NY,2)
-     DO K=1,NZ+1
-        WRITE(63)((Z1(I,J,K),I=1,NX),J=1,NY,2)
-     END DO
-     DO K=1,NZ+1
-        WRITE(63)((P1(I,J,K),I=1,NX),J=1,NY,2)
-     END DO
-     DO K=1,NZ
-        WRITE(63)((T1(I,J,K),I=1,NX),J=1,NY,2)
-     END DO
-     DO K=1,NZ
-        WRITE(63)((Q1(I,J,K),I=1,NX),J=1,NY,2)
-     END DO
-     DO K=1,NZ
-        WRITE(63)((U1(I,J,K),I=1,NX),J=1,NY,2)
-     END DO
-     DO K=1,NZ
-        WRITE(63)((V1(I,J,K),I=1,NX),J=1,NY,2)
-     END DO
+!JH Shin: Blocked output fort.63 since it is not used
+!     WRITE(63)((SLP1(I,J),I=1,NX),J=1,NY,2)
+!     DO K=1,NZ+1
+!        WRITE(63)((Z1(I,J,K),I=1,NX),J=1,NY,2)
+!     END DO
+!     DO K=1,NZ+1
+!        WRITE(63)((P1(I,J,K),I=1,NX),J=1,NY,2)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(63)((T1(I,J,K),I=1,NX),J=1,NY,2)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(63)((Q1(I,J,K),I=1,NX),J=1,NY,2)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(63)((U1(I,J,K),I=1,NX),J=1,NY,2)
+!     END DO
+!     DO K=1,NZ
+!        WRITE(63)((V1(I,J,K),I=1,NX),J=1,NY,2)
+!     END DO
 
       STOP
 
@@ -2634,6 +3096,112 @@
 !     WRITE(64)((USCM(I,J),I=1,NX),J=1,NY,2)
 !     WRITE(64)((VSCM(I,J),I=1,NX),J=1,NY,2)
 
+!---------------------------------------------------------------------
+      if(ivi_cloud.ge.1)then
+! Now, merged or relocated cloud & DZDT fields are changed back from
+! constant pressure level (PCST) to newly adjusted model pressure level(PMID1)
+! To save computational time, this is done only 900 by 900 with respect
+! to the TC center
+      write(*,*) 'START reverting from pressure to hybrid level!'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=jctr-450,jctr+450
+        DO I=ictr-450,ictr+450
+        nloop3: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PCST(1))THEN            ! Below PMID1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              QC(I,J,N)=QCP(I,J,1)
+              QR(I,J,N)=QRP(I,J,1)
+              QS(I,J,N)=QSP(I,J,1)
+              QG(I,J,N)=QGP(I,J,1)
+              QI(I,J,N)=QIP(I,J,1)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT(I,J,N)=DZDTP(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PCST(KMX))THEN
+             if(itag_c(i,j).eq.1)then
+              QC(I,J,N)=QCP(I,J,KMX)
+              QR(I,J,N)=QRP(I,J,KMX)
+              QS(I,J,N)=QSP(I,J,KMX)
+              QG(I,J,N)=QGP(I,J,KMX)
+              QI(I,J,N)=QIP(I,J,KMX)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT(I,J,N)=DZDTP(I,J,KMX)
+             endif
+            ELSE
+              DO K=1,KMX-1
+                IF(PMID1(I,J,N).LE.PCST(K).and.PMID1(I,J,N).GT.PCST(K+1))THEN
+                  W1=ALOG(1.*PCST(K+1))-ALOG(1.*PCST(K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PCST(K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   QC(I,J,N)=QCP(I,J,K)+ &
+                           (QCP(I,J,K+1)-QCP(I,J,K))*W
+                   QR(I,J,N)=QRP(I,J,K)+ &
+                           (QRP(I,J,K+1)-QRP(I,J,K))*W
+                   QS(I,J,N)=QSP(I,J,K)+ &
+                           (QSP(I,J,K+1)-QSP(I,J,K))*W
+                   QG(I,J,N)=QGP(I,J,K)+ &
+                           (QGP(I,J,K+1)-QGP(I,J,K))*W
+                   QI(I,J,N)=QIP(I,J,K)+ &
+                           (QIP(I,J,K+1)-QIP(I,J,K))*W
+                  endif
+                  if(itag_w(i,j).eq.1)then
+                   DZDT(I,J,N)=DZDTP(I,J,K)+ &
+                           (DZDTP(I,J,K+1)-DZDTP(I,J,K))*W
+                  endif
+                  cycle nloop3
+                END IF
+              END DO
+            END IF
+          END DO nloop3
+        END DO
+      END DO
+
+!============== Same interpolcaton for Thompson microphysics =========
+      if(ivi_cloud.eq.2)then
+      print*,'Interpolation for two additional Thompson variables:Final'
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=jctr-450,jctr+450
+        DO I=ictr-450,ictr+450
+        nloop4: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PCST(1))THEN            ! Below PMID1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              NCI(I,J,N)=NCIP(I,J,1)
+              NCR(I,J,N)=NCRP(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PCST(KMX))THEN
+             if(itag_c(i,j).eq.1)then
+              NCI(I,J,N)=NCIP(I,J,KMX)
+              NCR(I,J,N)=NCRP(I,J,KMX)
+             endif
+            ELSE
+              DO K=1,KMX-1
+                IF(PMID1(I,J,N).LE.PCST(K).and.PMID1(I,J,N).GT.PCST(K+1))THEN
+                  W1=ALOG(1.*PCST(K+1))-ALOG(1.*PCST(K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PCST(K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   NCI(I,J,N)=NCIP(I,J,K)+ &
+                           (NCIP(I,J,K+1)-NCIP(I,J,K))*W
+                   NCR(I,J,N)=NCRP(I,J,K)+ &
+                           (NCRP(I,J,K+1)-NCRP(I,J,K))*W
+                  endif
+                  cycle nloop4
+                END IF
+              END DO
+            END IF
+          END DO nloop4
+        END DO
+       END DO
+      endif
+!============= Done for Thompson microphysics configuration ===============
+
+      write(*,*) 'DONE reverting from pressure to hybrid level!'
+      endif
+!---------------------------------------------------------------------
+
       IUNIT=56
 
       WRITE(IUNIT) NX,NY,NZ,I360
@@ -2651,6 +3219,17 @@
       WRITE(IUNIT) PD1
       WRITE(IUNIT) ETA1
       WRITE(IUNIT) ETA2
+      if(ivi_cloud.ge.1)then
+       WRITE(IUNIT) QC
+       WRITE(IUNIT) QR
+       WRITE(IUNIT) QI
+       WRITE(IUNIT) QS
+       WRITE(IUNIT) QG
+       if(ivi_cloud.eq.2)then
+        WRITE(IUNIT) NCI
+        WRITE(IUNIT) NCR
+       endif
+      endif
 
       CLOSE(IUNIT)
 
@@ -2803,3 +3382,224 @@
       END
 
 !==============================================================================
+!=========================================================================
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine relocation(val,nx,ny,nz,nd,na,nb,irange,ictr,jctr,icst,jcst,itag,maxsmth)
+      implicit none
+      integer i,j,k,n,nx,ny,nz,nd,ictr,jctr,icst,jcst,irange,na,nb,maxsmth
+      real val(nx,ny,nz),tcval(nd,nd,nz),val_2d(nx,ny),val_save(nx,ny)
+      integer itag(nx,ny)
+      real dx,dy,range,dis,dis1,dis2
+      dx = 0.02
+      dy = 0.02
+      range = irange*dx
+
+      do k=na,nb
+
+       val_save(:,:)=val(:,:,k)
+      ! Get the GFS field from the "irange" grid points from the model TC center
+       do i=icst-irange,icst+irange
+        do j=jcst-irange,jcst+irange
+         tcval(i-icst+irange+1,j-jcst+irange+1,k) = val(i,j,k)
+        enddo
+       enddo
+
+       do j=1,nd
+        do i=1,nd
+         dis = sqrt(((dx*(i-(nd+1)/2))**2+(dy*(j-(nd+1)/2))**2))
+         if(dis.ge.range) tcval(i,j,k) = 0.0
+        enddo
+       enddo
+      ! Get the GFS field from the "irange" grid points from the model TC center
+
+      ! REPLACE cloud and W fields with the above extracted field within the
+      ! certain radius (6 dgrees for cloud, 3 degree for DZDT) from
+      ! TCvital location (ictr,jctr)
+       do i=ictr-irange,ictr+irange
+        do j=jctr-irange,jctr+irange
+         if( sqrt(((dx*(i-ictr))**2)+((dy*(j-jctr))**2)) .lt. range )then
+          val(i,j,k)=tcval(i-ictr+irange+1,j-jctr+irange+1,k)
+         endif
+        enddo
+       enddo
+
+       ! Do some smoothing on the boundary of modified region
+       ! When there is no relocation in the cold start, smoothing will
+       ! be skipped
+       if( icst.ne.ictr .or. jcst.ne.jctr)then
+        do n=1,maxsmth
+         val_2d(:,:)=val(:,:,k)
+         call smooth(val_2d,nx,ny,ictr,jctr,range,dx,dy)
+         val(:,:,k)=val_2d(:,:)
+        enddo
+       endif
+
+       ! itag(i,j) = 1 indicates where the cloud or W are modified
+       do j=1,ny
+        do i=1,nx
+         dis1 = sqrt(((dx*(i-icst))**2+(dy*(j-jcst))**2))
+         if( dis1.le.(range+0.5) ) itag(i,j) = 1
+         dis2 = sqrt(((dx*(i-ictr))**2+(dy*(j-jctr))**2))
+         if( dis2.le.(range+0.5) ) itag(i,j) = 1
+        enddo
+       enddo
+
+      enddo
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!=========================================================================
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine relocation_hafs(val,val2,nx,ny,nz,nd,na,nb,irange,ictr,jctr,icst,jcst,itag,maxsmth)
+      implicit none
+      integer i,j,k,n,nx,ny,nz,nd,ictr,jctr,icst,jcst,irange,na,nb,maxsmth
+      real val(nx,ny,nz),val2(nx,ny,nz),tcval2(nd,nd,nz),val_2d(nx,ny),val_save(nx,ny)
+      integer itag(nx,ny)
+      real dx,dy,range,dis,dis2
+      dx = 0.02
+      dy = 0.02
+      range = irange*dx
+      !val: Fields from GFS backgroud
+      !val2: Fields from HAFS 6-h forecast
+
+      do k=na,nb
+
+       val_save(:,:)=val(:,:,k)
+      ! Get the HAFS field from the "irange" grid points from the model TC cetner
+       do i=icst-irange,icst+irange
+        do j=jcst-irange,jcst+irange
+         tcval2(i-icst+irange+1,j-jcst+irange+1,k) = val2(i,j,k)
+        enddo
+       enddo
+
+       do j=1,nd
+        do i=1,nd
+         dis = sqrt(((dx*(i-(nd+1)/2))**2+(dy*(j-(nd+1)/2))**2))
+         if(dis.ge.range) tcval2(i,j,k) = 0.0
+        enddo
+       enddo
+      ! Get the HAFS field from the "irange" grid points from the model TC cetner
+
+      ! Replace GFS fields with the HAFS fields within the
+      ! certain radius (6 dgrees for cloud, 3 degree for DZDT) from
+      ! TCvital location (ictr,jctr)
+       do i=ictr-irange,ictr+irange
+        do j=jctr-irange,jctr+irange
+         if( sqrt(((dx*(i-ictr))**2)+((dy*(j-jctr))**2)) .lt. range )then
+          val(i,j,k)=tcval2(i-ictr+irange+1,j-jctr+irange+1,k)
+         endif
+        enddo
+       enddo
+
+       ! Do some smoothing on the boundary of modified region
+       do n=1,maxsmth
+        val_2d(:,:)=val(:,:,k)
+        call smooth(val_2d,nx,ny,ictr,jctr,range,dx,dy)
+        val(:,:,k)=val_2d(:,:)
+       enddo
+
+       ! itag(i,j) = 1 indicates where the cloud or W are modified
+       do j=1,ny
+        do i=1,nx
+         dis2 = sqrt(((dx*(i-ictr))**2+(dy*(j-jctr))**2))
+         if( dis2.le.(range+0.5) ) itag(i,j) = 1
+        enddo
+       enddo
+
+      enddo
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!====================================================================================
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine smooth(val,nx,ny,icen,jcen,range,dx,dy)
+      implicit none
+      integer i,j,nx,ny,icen,jcen
+      real val(nx,ny),val_tmp(nx,ny)
+      real dx,dy,range,dis
+
+      val_tmp=val
+!$omp parallel do &
+!$omp& private(i,j,dis)
+      do j=1,ny
+       do i=1,nx
+        dis = sqrt(((dx*(i-icen))**2+(dy*(j-jcen))**2))
+        if( dis.le.(range+0.5) .and. dis.ge.(range-0.5) )then
+         val(i,j)=     &
+         ( val_tmp(i,j-1)+val_tmp(i+1,j-1)+val_tmp(i-1,j-1)+   &
+           val_tmp(i,j) + val_tmp(i+1,j) + val_tmp(i-1,j)+     &
+           val_tmp(i,j+1)+val_tmp(i+1,j+1)+val_tmp(i-1,j+1) )/9.
+        endif
+       enddo
+      enddo
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+      subroutine findlev(qi,qc,qr,qs,qg,PCST,nx,ny,nz,icst,jcst,irange, &
+      nk,isnow,nice,meltlev,nqr,nqc,n100)
+      implicit none
+      integer i,j,k,nx,ny,nz,icst,jcst,irange,nk,nice,meltlev,nqr,nqc,n100,isnow
+      real deltp1,deltp
+      real qi(nx,ny,nz),qc(nx,ny,nz),qr(nx,ny,nz),qs(nx,ny,nz),qg(nx,ny,nz)
+      real PCST(nz)
+
+      do k=nz,1,-1
+       if(maxval(QI(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         nk=k
+         write(*,*) 'ICE TOP lev=',k
+         exit
+       endif
+      enddo
+      do k=1,nz
+       if(maxval(QI(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         write(*,*) 'ICE BOTTOM lev=',k
+         nice=k
+         exit
+       endif
+      enddo
+      do k=nz,1,-1
+       if(maxval(QS(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         write(*,*) 'SNOW TOP lev=',k
+         isnow=k
+         exit
+       endif
+      enddo
+      do k=1,nz
+       if(maxval(QG(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         write(*,*) 'GRAUPAL BOTTOM lev=',k
+         meltlev=k
+         exit
+       endif
+      enddo
+      !do k=1,nz
+      ! if(maxval(QR(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+      !   write(*,*) 'RAIN WATER BOTTOM lev=',k
+      !   nqr=k
+      !   exit
+      ! endif
+      !enddo
+      nqr=1 ! for RAIN WATER BOTTOM lev, we can set as 1
+      do k=nz,1,-1
+       if(maxval(QC(icst-irange:icst+irange,jcst-irange:jcst+irange,k)).gt.1.0E-07)then
+         nqc=k
+         write(*,*) 'CLOUD TOP lev=',k
+         exit
+       endif
+      enddo
+      deltp=1.e20
+      do k=nz,1,-1
+         deltp1=abs(PCST(k)-10000.)
+         if (deltp1.lt.deltp) then
+            deltp=deltp1
+            n100=k
+         endif
+      enddo
+      write(*,*) '100-hPa lev for vertical velocity change= ',n100,' ',PCST(n100)
+
+      end
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

--- a/sorc/hafs_tools.fd/sorc/hafs_vi/anl_enhance/anl_enhance.f90
+++ b/sorc/hafs_tools.fd/sorc/hafs_vi/anl_enhance/anl_enhance.f90
@@ -6,6 +6,18 @@
 ! REVISED  AUTHOR: QINGFU LIU, 2013
 !                : Use observed ROCI and Rmax to correct the composite storm
 !                : (old version uses the averaged values from obs and model)
+! REVISED  AUTHOR: JungHoon Shin Feb 2023 NCEP/EMC
+!                  This code reads cloud and vertical velocity fields,
+!                  which is modified by anl_combine.f90, and
+!                  re-interpolcates those variables into newly adjusted
+!                  model pressure level (PMID1) in the TC core region
+! REVISED  AUTHOR: JungHoon Shin July 2023 NCEP/EMC
+!                  The code is updated further with one more input argument (ivi_cloud)
+!                  so that cloud modification can be on (1 or 2) or off (0).
+!                  0: No cloud changes in VI, 1: GFDL microphysics, 2: Thompson microphysics
+!                  This change requires changes in exhafs_atm_vi.sh
+!                  Now input arguement is like this:
+!  ./hafs_vi_anl_enhance.x 6 ${pubbasin2} ${iflag_cold} ${vi_cloud}
 !
 !     DECLARE VARIABLES
 !
@@ -15,7 +27,7 @@
       integer ITIM,IUNIT,I360,iflag_cold,IM1,JM1,id_storm,KST
       integer ICLAT,ICLON,Ipsfc,Ipcls,Irmax,ivobs,Ir_vobs,IFLAG,K850
       integer ictr,jctr,imn1,imx1,jmn1,jmx1,imax1,jmax1,iter,IMV,JMV
-      integer imax12,jmax12,i_psm,j_psm,k1,ics
+      integer imax12,jmax12,i_psm,j_psm,k1,ics,icen,jcen
       real GAMMA,G,Rd,D608,Cp,GRD,COEF1,COEF2,COEF3,DST1,TENV1,press1
       real pi,pi_deg,arad,rad,TV1,ZSF1,PSF1,A,SUM11,vobs,vobs_o,VRmax
       real SLP1_MEAN,SLP_AVE,SLP_SUM,SLP_MIN,DP_CT,psfc_obs,psfc_cls,PRMAX
@@ -25,6 +37,7 @@
       real UU11,VV11,UUM1,VVM1,QQ1,uv22,QQ,beta1,vmax_1,ff0,ps_min,beta11
       real DIF,U_2S3,WT1,WT2,strm11,strm22,force,force2,PS_C1,PS_C2
       real fact,pt_c1,ps_rat,TEK1,TEK2,ESRR,T_OLD,Q_OLD,ZSFC,TSFC,QENV1
+      real dx,dy,dis
 
 !
       PARAMETER (NST=5,IR=200)
@@ -43,6 +56,12 @@
       REAL(4) LON1,LAT1,LON2,LAT2
 
       REAL(4), ALLOCATABLE :: T1(:,:,:),Q1(:,:,:)
+      REAL(4), ALLOCATABLE :: QC(:,:,:),QR(:,:,:),QS(:,:,:)      !Cloud on hybrid level-from anl_combine
+      REAL(4), ALLOCATABLE :: QI(:,:,:),QG(:,:,:)                !Cloud on hybrid level-from anl_combine
+      REAL(4), ALLOCATABLE :: NCI(:,:,:),NCR(:,:,:) !Cloud concentration on hybrid level-from anl_combine
+      REAL(4), ALLOCATABLE :: QC2(:,:,:),QR2(:,:,:),QS2(:,:,:)   !Final cloud on hybrid level
+      REAL(4), ALLOCATABLE :: QI2(:,:,:),QG2(:,:,:),DZDT2(:,:,:) !Final cloud & W on hybrid level
+      REAL(4), ALLOCATABLE :: NCI2(:,:,:),NCR2(:,:,:)  !Final cloud concentration on hybrid level
       REAL(4), ALLOCATABLE :: U1(:,:,:),V1(:,:,:),DZDT(:,:,:)
       REAL(4), ALLOCATABLE :: Z1(:,:,:),P1(:,:,:)
       REAL(4), ALLOCATABLE :: GLON(:,:),GLAT(:,:)
@@ -69,7 +88,7 @@
 ! working array
 
       REAL(4), ALLOCATABLE :: SLP1(:,:),RIJ(:,:)
-      REAL(4), ALLOCATABLE :: PMID1(:,:,:),ZMID1(:,:,:)
+      REAL(4), ALLOCATABLE :: PMID1(:,:,:),ZMID1(:,:,:),PMID2(:,:,:) !PMID2 will be used for cloud & W
       REAL(4), ALLOCATABLE :: ZS1(:,:),TS1(:,:),QS1(:,:)
 
       REAL(4), ALLOCATABLE :: HLON(:,:),HLAT(:,:)
@@ -117,6 +136,8 @@
 
       REAL(4), ALLOCATABLE :: dist(:,:),PW1(:)
 
+      integer(4), ALLOCATABLE :: itag_c(:,:),itag_w(:,:) ! Tag array for cloud & W relocation
+
       integer(4) IH1(4),JH1(4),IV1(4),JV1(4)
 
       REAL(8) CLON_NEW,CLAT_NEW,CLON_NHC,CLAT_NHC
@@ -132,6 +153,8 @@
       CHARACTER SN*1,EW*1,DEPTH*1
 !zhang:added basin domain shift option
       CHARACTER*2 :: basin
+!shin: cloud modification option
+      integer :: ivi_cloud
 
 !      DATA PW_S/30*1.0,0.95,0.9,0.8,0.7,       &
 !                    0.6,0.5,0.4,0.3,0.2,0.1,45*0./
@@ -155,6 +178,8 @@
        0.5,0.45,0.4,0.35,0.3,0.25,0.2,0.15,0.1,0.05/)
       PW_M(70:121)=0.0
 
+      dx=0.02        !Grid size in degree of VI input
+      dy=0.02        !Grid size in degree of VI input
 
       COEF1=Rd/Cp
       COEF3=Rd*GAMMA/G
@@ -169,8 +194,10 @@
       arad=6.371E6*rad
       DST1=6.371E6*rad
 
-      READ(5,*)ITIM,basin,iflag_cold
-
+      READ(5,*)ITIM,basin,iflag_cold,ivi_cloud
+      if(ivi_cloud.eq.0) write(*,*) 'Cloud modification is OFF!!'
+      if(ivi_cloud.eq.1) write(*,*) 'Cloud change is ON (GFDL)!!'
+      if(ivi_cloud.eq.2) write(*,*) 'Cloud change is ON (Thompson)!!'
 
 ! READ NEW GFS Env. DATA (New Domain)
 
@@ -198,8 +225,15 @@
       ALLOCATE ( VLON(NX,NY),VLAT(NX,NY) )
 
       ALLOCATE ( PCK(NZ),TEK(NZ),TEK42(KMX2) )
-      ALLOCATE ( dist(NX,NY) )
+      ALLOCATE ( dist(NX,NY), itag_c(NX,NY), itag_w(NX,NY) )
       ALLOCATE ( PMID1(NX,NY,NZ),ZMID1(NX,NY,NZ) )
+      ALLOCATE ( QC(NX,NY,NZ),QR(NX,NY,NZ),QI(NX,NY,NZ) )
+      ALLOCATE ( QS(NX,NY,NZ),QG(NX,NY,NZ) )
+      ALLOCATE ( NCI(NX,NY,NZ),NCR(NX,NY,NZ) )
+      ALLOCATE ( QC2(NX,NY,NZ),QR2(NX,NY,NZ),QI2(NX,NY,NZ) )
+      ALLOCATE ( QS2(NX,NY,NZ),QG2(NX,NY,NZ) )
+      ALLOCATE ( NCI2(NX,NY,NZ),NCR2(NX,NY,NZ) )
+      ALLOCATE ( DZDT2(NX,NY,NZ),PMID2(NX,NY,NZ) )
 
       READ(IUNIT) LON1,LAT1,LON2,LAT2,CENTRAL_LON,CENTRAL_LAT
       READ(IUNIT) PMID1
@@ -207,7 +241,7 @@
       READ(IUNIT) Q1
       READ(IUNIT) U1
       READ(IUNIT) V1
-      READ(IUNIT) DZDT
+      READ(IUNIT) DZDT  ! vertical velocity from anl_combine
       READ(IUNIT) Z1
 !      READ(IUNIT) GLON,GLAT
       READ(IUNIT) HLON,HLAT,VLON,VLAT
@@ -218,8 +252,23 @@
 
       READ(IUNIT) USC
       READ(IUNIT) VSC
+      if(ivi_cloud.ge.1)then
+       READ(IUNIT) QC     ! cloud from anl_combine
+       READ(IUNIT) QR     ! rain from anl_combine
+       READ(IUNIT) QI     ! ice from anl_combine
+       READ(IUNIT) QS     ! snow from anl_combine
+       READ(IUNIT) QG     ! graupel from anl_combine
+       if(ivi_cloud.eq.2)then
+        print*,'Cloud ice and rain number concentrations'
+        READ(IUNIT) NCI    ! Cloud ice water number concentration
+        READ(IUNIT) NCR    ! Rain number concentration
+       endif
+      endif
 
       CLOSE(IUNIT)
+
+      PMID2=PMID1
+      ! Original PMID1 will be save as PMID2 for re-interploation into newly adjusted PMID1
 
       ALLOCATE ( SLP1(NX,NY),RIJ(NX,NY) )
       ALLOCATE ( ZS1(NX,NY),TS1(NX,NY),QS1(NX,NY) )
@@ -351,26 +400,26 @@
 
 ! finsih compute 10m wind
 
-
-      WRITE(62)((SLP1(I,J),I=1,NX),J=1,NY,2)
-      DO K=1,NZ+1
-        WRITE(62)((Z1(I,J,K),I=1,NX),J=1,NY,2)
-      END DO
-      DO K=1,NZ+1
-        WRITE(62)((P1(I,J,K),I=1,NX),J=1,NY,2)
-      END DO
-      DO K=1,NZ
-        WRITE(62)((T1(I,J,K),I=1,NX),J=1,NY,2)
-      END DO
-      DO K=1,NZ
-        WRITE(62)((Q1(I,J,K),I=1,NX),J=1,NY,2)
-      END DO
-      DO K=1,NZ
-        WRITE(62)((U1(I,J,K),I=1,NX),J=1,NY,2)
-      END DO
-      DO K=1,NZ
-        WRITE(62)((V1(I,J,K),I=1,NX),J=1,NY,2)
-      END DO
+!JH Shin: Blocked output fort.62 since it is not used
+!      WRITE(62)((SLP1(I,J),I=1,NX),J=1,NY,2)
+!      DO K=1,NZ+1
+!        WRITE(62)((Z1(I,J,K),I=1,NX),J=1,NY,2)
+!      END DO
+!      DO K=1,NZ+1
+!        WRITE(62)((P1(I,J,K),I=1,NX),J=1,NY,2)
+!      END DO
+!      DO K=1,NZ
+!        WRITE(62)((T1(I,J,K),I=1,NX),J=1,NY,2)
+!      END DO
+!      DO K=1,NZ
+!        WRITE(62)((Q1(I,J,K),I=1,NX),J=1,NY,2)
+!      END DO
+!      DO K=1,NZ
+!        WRITE(62)((U1(I,J,K),I=1,NX),J=1,NY,2)
+!      END DO
+!      DO K=1,NZ
+!        WRITE(62)((V1(I,J,K),I=1,NX),J=1,NY,2)
+!      END DO
 
 !Not used      WBD=-(NX-1)*DLMD
 !Not used      SBD=-((NY-1)/2)*DPHD
@@ -1381,7 +1430,7 @@
        END DO
        END DO
 
-       print*,'surgace pressure=',press1
+       print*,'surface pressure=',press1
 
        DO J=1,NY
        DO I=1,NX
@@ -1389,6 +1438,146 @@
          V1(I,J,1)=VSC2(I,J)
        END DO
        END DO
+
+!-------------------------------------------------------------------------
+      if(ivi_cloud.ge.1)then
+! From PMID2 to PMID1
+! As PMID1 is newly adjusted in the core region of hurricanes,
+! cloud and vertical velocity fields in the PMID2 are interpoloated into
+! newly adjusted model pressure level PMID1
+! To save computational time, this is done within 6 (2) degrees with
+! respect to the TC center for cloud (vertical velocity) field
+! QC,QR,QI,QS,QG,DZDT: variables in the old PMID1 (i.e.,PMID2) level
+! QC2,QR2,QI2,QS2,QG2,DZDT2: variables in the newly adjusted model
+! pressure level PMID1
+
+      itag_c=0
+      itag_w=0
+
+!$omp parallel do &
+!$omp& private(i,j,dis)
+      do j=1,ny
+       do i=1,nx
+        dis = sqrt( (dx*(i-ictr))**2+(dy*(j-jctr))**2 )
+        if( dis.lt.6.0 ) itag_c(i,j)=1
+        if( dis.lt.2.0 ) itag_w(i,j)=1
+       enddo
+      enddo
+
+! put the variables and only core region will be replaced
+      QC2=QC
+      QR2=QR
+      QS2=QS
+      QG2=QG
+      QI2=QI
+      DZDT2=DZDT
+
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+      DO J=jctr-450,jctr+450     !Do loop for 900x900 with respect to TC center is fine
+        DO I=ictr-450,ictr+450
+        nloop1: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PMID2(I,J,1))THEN            ! Below PMV1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              QC2(I,J,N)=QC(I,J,1)
+              QR2(I,J,N)=QR(I,J,1)
+              QS2(I,J,N)=QS(I,J,1)
+              QG2(I,J,N)=QG(I,J,1)
+              QI2(I,J,N)=QI(I,J,1)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT2(I,J,N)=DZDT(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PMID2(I,J,NZ))THEN
+             if(itag_c(i,j).eq.1)then
+              QC2(I,J,N)=QC(I,J,NZ)
+              QR2(I,J,N)=QR(I,J,NZ)
+              QS2(I,J,N)=QS(I,J,NZ)
+              QG2(I,J,N)=QG(I,J,NZ)
+              QI2(I,J,N)=QI(I,J,NZ)
+             endif
+             if(itag_w(i,j).eq.1)then
+              DZDT2(I,J,N)=DZDT(I,J,NZ)
+             endif
+            ELSE
+              DO K=1,NZ-1
+                IF(PMID1(I,J,N).LE.PMID2(I,J,K).and.PMID1(I,J,N).GT.PMID2(I,J,K+1))THEN
+                  W1=ALOG(1.*PMID2(I,J,K+1))-ALOG(1.*PMID2(I,J,K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PMID2(I,J,K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   QC2(I,J,N)=QC(I,J,K)+ &
+                           (QC(I,J,K+1)-QC(I,J,K))*W
+                   QR2(I,J,N)=QR(I,J,K)+ &
+                           (QR(I,J,K+1)-QR(I,J,K))*W
+                   QS2(I,J,N)=QS(I,J,K)+ &
+                           (QS(I,J,K+1)-QS(I,J,K))*W
+                   QG2(I,J,N)=QG(I,J,K)+ &
+                           (QG(I,J,K+1)-QG(I,J,K))*W
+                   QI2(I,J,N)=QI(I,J,K)+ &
+                           (QI(I,J,K+1)-QI(I,J,K))*W
+                  endif
+                  if(itag_w(i,j).eq.1)then
+                   DZDT2(I,J,N)=DZDT(I,J,K)+ &
+                           (DZDT(I,J,K+1)-DZDT(I,J,K))*W
+                  endif
+                  cycle nloop1
+                END IF
+              END DO
+            END IF
+          END DO nloop1
+        END DO
+      END DO
+
+!======= Same interpolation for two additional Thompson microphysics variables
+      if(ivi_cloud.eq.2)then
+      print*,'Same interpolation for two additional Thompson variables'
+       NCI2=NCI
+       NCR2=NCR
+
+!$omp parallel do &
+!$omp& private(i,j,k,N,W1,W)
+       DO J=jctr-450,jctr+450     !Do loop for 900x900 with respect to TC center is fine
+        DO I=ictr-450,ictr+450
+        nloop2: DO N=1,NZ
+            IF(PMID1(I,J,N).GE.PMID2(I,J,1))THEN            ! Below PMV1(I,J,1)
+             if(itag_c(i,j).eq.1)then
+              NCI2(I,J,N)=NCI(I,J,1)
+              NCR2(I,J,N)=NCR(I,J,1)
+             endif
+            ELSE IF(PMID1(I,J,N).LE.PMID2(I,J,NZ))THEN
+             if(itag_c(i,j).eq.1)then
+              NCI2(I,J,N)=NCI(I,J,NZ)
+              NCR2(I,J,N)=NCR(I,J,NZ)
+             endif
+            ELSE
+              DO K=1,NZ-1
+                IF(PMID1(I,J,N).LE.PMID2(I,J,K).and.PMID1(I,J,N).GT.PMID2(I,J,K+1))THEN
+                  W1=ALOG(1.*PMID2(I,J,K+1))-ALOG(1.*PMID2(I,J,K))
+                  W=(ALOG(1.*PMID1(I,J,N))-ALOG(1.*PMID2(I,J,K)))/W1
+                  if(itag_c(i,j).eq.1)then
+                   NCI2(I,J,N)=NCI(I,J,K)+ &
+                           (NCI(I,J,K+1)-NCI(I,J,K))*W
+                   NCR2(I,J,N)=NCR(I,J,K)+ &
+                           (NCR(I,J,K+1)-NCR(I,J,K))*W
+                  endif
+                  cycle nloop2
+                END IF
+              END DO
+            END IF
+          END DO nloop2
+        END DO
+       END DO
+
+      endif
+!===============  Done for Thompson microphysics configuration ================
+
+      endif
+!-------------------------------------------------------------------
+      if(ivi_cloud.eq.0) DZDT2=DZDT
+      ! If cloud relocation is off, simply output DZDT from
+      ! origonal data
+!-------------------------------------------------------------------
+!
 
 !      WRITE(64)((SLP1(I,J),I=1,NX),J=1,NY,2)
 !      DO K=1,NZ+1
@@ -1421,7 +1610,7 @@
       WRITE(IUNIT) Q1
       WRITE(IUNIT) U1
       WRITE(IUNIT) V1
-      WRITE(IUNIT) DZDT
+      WRITE(IUNIT) DZDT2
       WRITE(IUNIT) Z1
 !      WRITE(IUNIT) GLON,GLAT
       WRITE(IUNIT) HLON,HLAT,VLON,VLAT
@@ -1429,6 +1618,17 @@
       WRITE(IUNIT) PD1
       WRITE(IUNIT) ETA1
       WRITE(IUNIT) ETA2
+      if(ivi_cloud.ge.1)then
+       WRITE(IUNIT) QC2
+       WRITE(IUNIT) QR2
+       WRITE(IUNIT) QI2
+       WRITE(IUNIT) QS2
+       WRITE(IUNIT) QG2
+       if(ivi_cloud.eq.2)then
+        WRITE(IUNIT) NCI2
+        WRITE(IUNIT) NCR2
+       endif
+      endif
 
       CLOSE(IUNIT)
 


### PR DESCRIPTION
## Description of changes
Several script files and codes are updated/changed to add new cloud hydrometer variables and vertical velocity relocation/cycling capability in HAFS-VI, which will improve the intensity forecast and will provide a better initial condition (i.e., hurricane vortex) for the inner core DA.

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes hafs-community/HAFS/issues/203
