### PR TITLE
Point to the latest GPLOT `support/HAFS` branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "GPLOT"]
     path = sorc/hafs_graphics.fd/hrd_gplot
     url = https://github.com/hafs-community/GPLOT.git
-    branch = support/HAFS
+    branch = develop
 [submodule "hafs_graphics"]
     path = sorc/hafs_graphics.fd/emc_graphics
     url = https://github.com/hafs-community/hafs_graphics.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "GPLOT"]
     path = sorc/hafs_graphics.fd/hrd_gplot
     url = https://github.com/hafs-community/GPLOT.git
-    branch = release/0.4.0
+    branch = support/HAFS
 [submodule "hafs_graphics"]
     path = sorc/hafs_graphics.fd/emc_graphics
     url = https://github.com/hafs-community/hafs_graphics.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,7 @@
 [submodule "GPLOT"]
     path = sorc/hafs_graphics.fd/hrd_gplot
     url = https://github.com/hafs-community/GPLOT.git
-    branch = develop
+    branch = release/0.4.0
 [submodule "hafs_graphics"]
     path = sorc/hafs_graphics.fd/emc_graphics
     url = https://github.com/hafs-community/hafs_graphics.git


### PR DESCRIPTION
## Description of changes
Update the GPLOT submodule (`hafs_graphics.fd/hrd_gplot`) and .gitmodules file to point to the latest `release/0.4.0` branch. The branch is forked here:  https://github.com/hafs-community/GPLOT/tree/release/0.4.0

## Contributors (optional)
@lgramer @AndrewHazelton 

## Tests conducted
Extensive testing on Orion, Hera, and Jet.

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
