### PR TITLE
Updating the HAFS RT status script

### DIFF
--- a/rocoto/hafs_rt_status.sh
+++ b/rocoto/hafs_rt_status.sh
@@ -5,11 +5,11 @@
 # The script lists the *.xml files under $HAFS_dir/rocoto directory and gets
 # the different configuration names.
 # The script looks for:
-# 1. storm1.done 2. *hafs.trac.atcfunix.all
+# 1. storm1.done 2. post and prod logs 
 # 3. SUCCEEDED for completion task
 
 # Author: Mrinal Biswas DTC/NCAR
-# Do not contact: biswas@ucar.edu
+# Contact: biswas@ucar.edu
 
 #set -x
 
@@ -38,7 +38,6 @@ for file in *.xml; do
 
   if_complete=`rocotostat -d hafs-${subexpt}-${sid}-${storm_init}.db -w hafs-${subexpt}-${sid}-${storm_init}.xml|grep -e completion |grep -e SUCCEEDED|wc -l`
   storm1_done=${HAFS_out}/${subexpt}/com/${storm_init}/${sid}/storm1.done
-  atcfunix=$(/usr/bin/find ${HAFS_out}/${subexpt}/com/${storm_init}/${sid} -type f -name "*hafs.trak.atcfunix.all")
 
   # Check if rocoto completion task ran successfully or not
 
@@ -51,34 +50,34 @@ for file in *.xml; do
   # Check the post and product log files
 
   if [ $if_complete == "1" ] || [ $if_complete == "2" ]; then
-    post_log=`cat ${HAFS_out}/${subexpt}/${storm_init}/${sid}/hafs_atm_post.log|grep "post job done"|tail -1`
-    prod_log=`cat ${HAFS_out}/${subexpt}/${storm_init}/${sid}/hafs_product.log|grep "product job done"|tail -1`
-    if [[ $post_log == "post job done" ]]; then
+    post_log=`cat ${HAFS_out}/${subexpt}/${storm_init}/${sid}/hafs_atm_post1.log|grep "status=0"|tail -1|wc -l`
+    prod_log=`cat ${HAFS_out}/${subexpt}/${storm_init}/${sid}/hafs_product.log|grep "successfully ran run_product.parent"|tail -1|wc -l`
+    if [[ $post_log == "1" ]]; then
       echo "POST RAN TILL COMPLETION"
     else
       echo "POST DID NOT RAN TILL COMPLETION"
     fi
-    if [[ $prod_log == "product job done" ]]; then
+    if [[ $prod_log == "1" ]]; then
       echo "PRODUCT RAN TILL COMPLETION"
     else
       echo "PRODUCT DID NOT RAN TILL COMPLETION"
     fi
   fi
 
-  # Check storm1.done atcfunix and hafsprs.synoptic files
+  # Check storm1.done and atcfunix files
 
-  if [[ -e ${storm1_done} && -e ${atcfunix} ]]; then
-    echo "FOUND STORM1.DONE, TRACKER OUTPUT "
+  if [[ -e ${storm1_done} ]]; then
+    echo "FOUND STORM1.DONE"
   else
-    echo "STORM1.DONE, TRACKER OUTPUT DO NOT EXIST"
+    echo "STORM1.DONE DO NOT EXIST"
   fi
 
   # Check if everything passed
 
   if [ $if_complete == "1" ] || [ $if_complete == "2" ]; then
-    if [[ -e ${storm1_done} && -e ${atcfunix} ]]; then
-    if [[ $post_log == "post job done" ]]; then
-    if [[ $prod_log == "product job done" ]]; then
+    if [[ -e ${storm1_done} ]]; then
+    if [[ $post_log == "1" ]]; then
+    if [[ $prod_log == "1" ]]; then
       echo "REGRESSION TEST PASSED!! YAYYY!!"
     else
       echo "REGRESSION TEST FAILED!! IT'S NOT YOUR FAULT!!"


### PR DESCRIPTION
## Description of changes
This PR will update the HAFS RT status script and address Issue#218. The script is now updated to look into the correct files of post and prod log files. The checking of the tracker output is now removed. 

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes hafs-community/HAFS/issues/218

## Tests conducted
Ran RTs with the develop branch on Orion. Scripts run without issues. 

## Application-level regression test status

No RTs are needed for the PR. The script is isolated from the workflow. 

Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
