### PR TITLE
Merge hafs.v1.0.5 back to develop

### DIFF
--- a/parm/hfsa_other_basins.conf
+++ b/parm/hfsa_other_basins.conf
@@ -15,3 +15,6 @@ run_envar=no
 gsi_d01=no
 gsi_d02=no
 run_analysis_merge=yes
+
+[forecast]
+ntrack=0,4

--- a/parm/hfsa_other_basins.conf
+++ b/parm/hfsa_other_basins.conf
@@ -18,3 +18,4 @@ run_analysis_merge=yes
 
 [forecast]
 ntrack=0,4
+max_slope=0.12,0.12

--- a/scripts/exhafs_atm_vi.sh
+++ b/scripts/exhafs_atm_vi.sh
@@ -60,6 +60,8 @@ else
   ${NCP} ${WORKhafs}/tmpvit tcvitals.vi
   gesfhr=6
 fi
+# Convert 1800W to 1800E for date line TCs
+sed -i 's/1800W/1800E/g' ./tcvitals.vi
 tcvital=${DATA}/tcvitals.vi
 # Extract vmax from tcvitals (m/s)
 vmax_vit=$(cat ${tcvital} | cut -c68-69 | bc -l)
@@ -185,6 +187,8 @@ if [[ ${vmax_vit} -ge ${vi_warm_start_vmax_threshold} ]] && [ -d ${RESTARTinp} ]
     ${NCP} ${COMOLD}/${old_out_prefix}.${RUN}.trak.atcfunix.all ./trak.atcfunix.all
     # rename basin id for Southern Hemisphere or Northern Indian Ocean storms
 	sed -i -e 's/^AA/IO/g' -e 's/^BB/IO/g' -e 's/^SP/SH/g' -e 's/^SI/SH/g' -e 's/^SQ/SL/g' ./trak.atcfunix.all
+    # Convert 1800W to 1800E for date line TCs
+	sed -i 's/1800W/1800E/g' ./trak.atcfunix.all
     if grep "^${pubbasin2^^}, ${old_out_prefix_nodate:0:2}," trak.atcfunix.all > trak.atcfunix.tmp ; then
       echo "trak.atcfunix.tmp generated."
     else
@@ -290,6 +294,8 @@ if true; then
     ${NCP} ${INTCOMinit}/${STORMID,,}.${CDATE}.${RUN}.trak.atcfunix.all ./trak.atcfunix.all
     # rename basin id for Southern Hemisphere or Northern Indian Ocean storms
 	sed -i -e 's/^AA/IO/g' -e 's/^BB/IO/g' -e 's/^SP/SH/g' -e 's/^SI/SH/g' -e 's/^SQ/SL/g' ./trak.atcfunix.all
+    # Convert 1800W to 1800E for date line TCs
+	sed -i 's/1800W/1800E/g' ./trak.atcfunix.all
     grep "^${pubbasin2^^}, ${STORMID:0:2}," trak.atcfunix.all \
       > trak.atcfunix.tmp
   else

--- a/scripts/exhafs_output.sh
+++ b/scripts/exhafs_output.sh
@@ -98,14 +98,14 @@ swath_grb2fhhh=${out_prefix}.${RUN}.${gridstr}.swath.f${FHR3}.grb2
 ${WGRIB2} ${COMhafs}/${grb2file} -match '(:GUST:)'           	-rpn "0:swap:merge" \
     -set_metadata_str "0:0:d=+0hr:GUST:10-10 m above ground:0-$((IFHR*DHR)) hour max fcst::Wind Speed (Gust) [m/s]:" \
     -grib_out ${GUSTF}
-${WGRIB2} ${COMhafs}/${grb2file} -match '(:APCP:)'           	-rpn "0:swap:merge" -grib_out ${APCPF}
+${WGRIB2} ${COMhafs}/${grb2file} | grep ":APCP:" | head -n 1 | ${WGRIB2} -i ${COMhafs}/${grb2file} 	-rpn "0:swap:merge" -grib_out ${APCPF}
 ${WGRIB2} ${APCPF} -match '(:APCP:)'            	-rpn "0:*" \
     -set_metadata_str "0:0:d=+0hr:PRATE:atmos col:0-$((IFHR*DHR)) hour ave fcst::Precipitation Rate [kg/m^2/s]:" \
     -grib_out ${PRATEF}
 ${WGRIB2} ${COMhafs}/${grb2file} -match '(:WIND.*max)'       	-rpn "0:swap:merge" \
     -set_metadata_str "0:0:d=+0hr:WIND:10-10 m above ground:0-$((IFHR*DHR)) hour max fcst::Wind Speed [m/s]:" \
     -grib_out ${WINDMAXF}
-${WGRIB2} ${COMhafs}/${grb2file} -match '(:ACPCP:)'          	-rpn "0:swap:merge" -grib_out ${ACPCPF}
+${WGRIB2} ${COMhafs}/${grb2file} | grep ":ACPCP:" | head -n 1 | ${WGRIB2} -i ${COMhafs}/${grb2file} -rpn "0:swap:merge" -grib_out ${ACPCPF}
 ${WGRIB2} ${ACPCPF} -match '(:ACPCP:)'            	-rpn "0:*" \
     -set_metadata_str "0:0:d=+0hr:CPRAT:atmos col:0-$((IFHR*DHR)) hour ave fcst::Convective Precipitation Rate [kg/m^2/s]:" \
     -grib_out ${CPRATF}
@@ -144,7 +144,7 @@ while [ $FHR -le $NHRS ]; do
   rm ${TMPFILE}
   mv ${TMPFILE2} ${GUSTF}
   # PRATE - accumulated total precipitation
-  ${WGRIB2} ${COMhafs}/${grb2file} -match '(:APCP:)'         	-rpn "0:swap:merge" -grib_out ${TMPFILE}
+  ${WGRIB2} ${COMhafs}/${grb2file} | grep ":APCP:" | head -n 1 | ${WGRIB2} -i ${COMhafs}/${grb2file} -rpn "0:swap:merge" -grib_out ${TMPFILE}
   ${WGRIB2} ${TMPFILE} -rpn "sto_1" -import_grib ${APCPF} -rpn "rcl_1:+" -grib_out ${TMPFILE2}
   rm ${TMPFILE}
   mv ${TMPFILE2} ${APCPF}
@@ -159,7 +159,7 @@ while [ $FHR -le $NHRS ]; do
   rm ${TMPFILE}
   mv ${TMPFILE2} ${WINDMAXF}
   # CPRAT - accumulated convective precipitation
-  ${WGRIB2} ${COMhafs}/${grb2file} -match '(:ACPCP:)'        	-rpn "0:swap:merge" -grib_out ${TMPFILE}
+  ${WGRIB2} ${COMhafs}/${grb2file} | grep ":ACPCP:" | head -n 1 | ${WGRIB2} -i ${COMhafs}/${grb2file} -rpn "0:swap:merge" -grib_out ${TMPFILE}
   ${WGRIB2} ${TMPFILE} -rpn "sto_1" -import_grib ${ACPCPF} -rpn "rcl_1:+" -grib_out ${TMPFILE2}
   rm ${TMPFILE}
   mv ${TMPFILE2} ${ACPCPF}

--- a/sorc/hafs_tools.fd/sorc/hafs_vi/create_trak_init/create_trak_init.f90
+++ b/sorc/hafs_tools.fd/sorc/hafs_vi/create_trak_init/create_trak_init.f90
@@ -19,8 +19,8 @@ program create_trak_init
   implicit none
   character(len=2)      :: part1,num,basin
   character(len=3)      :: part2,storm_id
-  character(len=1)      :: ns,ew
-  integer               :: ihour,idat,ifh,lat,lon,stat
+  character(len=1)      :: ns,ew,ns2,ew2
+  integer               :: ihour,idat,ifh,lat,lon,stat,idat2,ihour2,lat2,lon2
 
   integer               :: iargc
 
@@ -46,6 +46,10 @@ program create_trak_init
   lat=9999
   lon=9999
   ifh=-1
+
+  ! Read TCvital first
+    read(11,13) part2,idat2,ihour2,lat2,ns2,lon2,ew2
+    if(ns2.eq.'S')lat2=-lat2
 
   ! Reading fort.12 (atcfunix: GFS/GDAS vortex center)
   do
@@ -73,9 +77,18 @@ program create_trak_init
     else
       print*, 'Using tcvital information because lat and lon values of atcfunix is odd'
     endif
-    read(11,13) part2,idat,ihour,lat,ns,lon,ew
-    if(ns.eq.'S')lat=-lat
+    idat=idat2
+    ihour=ihour2
+    lat=lat2
+    lon=lon2
+    ew=ew2
+    ns=ns2
   endif
+
+  ! Only for TCs near date line: near the date line (180E or 180W), longitude of tcvital (ew2) and
+  ! that of ATCF (ew) could be different. In this case, convent longitude as following.
+  ! Then, split.f90 will handle rest of things
+  if(ew2.ne.ew) lon=3600-lon
 
   write(*,15) idat,ihour,lat,lon,lat,lon,lat,lon,lat,lon,lat,lon,lat,lon,lat,lon,storm_id
   write(30,15) idat,ihour,lat,lon,lat,lon,lat,lon,lat,lon,lat,lon,lat,lon,lat,lon,storm_id


### PR DESCRIPTION
## Description of changes
Merge the operational hafs.v1.0.5 version back to HAFS develop branch. The following changes are included in this PR.
 - Update max_slope from 0.15 to 0.12 for JTWC basin storms, in order to reduce forecast job failures due to the moving nest edge cutting through steep topography.
 - Update exhafs_output.sh to remove the duplicated and wrong PRATE and CPRAT records in the HAFS swath grib2 file. (From @LinZhu-NOAA)
 - Update create_trak_guess.f90, create_trak_init.f90, and exhafs_atm_vi.sh to handle storms specifically located at 180W in tcvitals or atcfunix track files (which is very rare though). Note: implemented and tested by @JunghoonShin-NOAA.
 - Update submodule hafs_tracker.fd, which fixed an error in output_atcfunix where there was an extra comma in the output record. (From Tim Marchok, 07/31/2023)
 - Update ntrack from 0,2 to 0,4 to reduce the internal tracker calling frequency for the moving nest for JTWC basin storms, basically, calling the internal tracker every 6 mins (instead of 3 mins). This can alleviate some forecast job failures due to the moving nest edge cutting through steep topography.
 
In addition, this PR also updates submodule sorc/hafs_tracker.fd to point to the latest commit of its support/HAFS branch, which enables supporting large files in cwaitfor by using 64-bit integer (from @SamuelTrahanNOAA).

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes hafs-community/HAFS/issues/222
- fixes hafs-community/HAFS/issues/216
- fixes hafs-community/HAFS/issues/208
- fixes hafs-community/HAFS/issues/215

## Contributors (optional)
If others worked on this PR besides the author, please include their user names here (using @Mention if possible).
@ZhanZhang-NOAA, @JunghoonShin-NOAA, @LinZhu-NOAA, @BijuThomas-NOAA, @yonghuiweng, @TimMarchok-NOAA, @SamuelTrahanNOAA 

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests, including relevant details about the configuration(s) (e.g., cold versus warm start, number of cycles, forecast length, whether data assimilation was performed, etc). What platform(s) were used for testing?
The operational HFSA and HFSB configurations have been tested on multiple platforms. Plus, the hafs.v1.0.5 has been operationally implemented on WCOSS2.

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [x] Hera
- [x] Orion
- [x] WCOSS2
