### PR TITLE
Update .readthedocs.yaml file to reenable doc builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,13 @@
 # .readthedocs.yml
-# Read the Docs configuration file
+# Read the Docs configuration file for HAFS
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
 # Required
 version: 2
+build: 
+  os: ubuntu-20.04
+  tools: 
+    python: "3.9"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -18,6 +22,5 @@ formats: all
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
   install:
     - requirements: docs/UsersGuide/requirements.txt


### PR DESCRIPTION
## Description of changes
This PR cures documentation build failures on ReadTheDocs. See the docs built from my fork here: https://gsp-hafs.readthedocs.io/en/text-rtd/

Build passed: 
![image](https://github.com/hafs-community/HAFS/assets/96886803/196be4de-98d5-4145-b3fd-0fd7c8a1d93c)
(Note that the builds labeled "latest" failed because they are a copy of develop, which does not yet have these changes incorporated.)


## Issues addressed (optional)
- Fixes Issue #228 

## Dependencies (optional)
N/A

## Contributors (optional)
N/A

## Tests conducted
None required. 

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
