### PR TITLE
Use the latest default version of Rocoto on RDHPCS platforms

### DIFF
--- a/modulefiles/hafs.hera.lua
+++ b/modulefiles/hafs.hera.lua
@@ -121,7 +121,7 @@ cdo_ver=os.getenv("cdo_ver") or "1.9.8"
 load(pathJoin("cdo", cdo_ver))
 
 rocoto_ver=os.getenv("rocoto_ver") or "1.3.3"
-load(pathJoin("rocoto", rocoto_ver))
+load("rocoto")
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")

--- a/modulefiles/hafs.jet.lua
+++ b/modulefiles/hafs.jet.lua
@@ -119,7 +119,7 @@ cdo_ver=os.getenv("cdo_ver") or "1.9.10"
 load(pathJoin("cdo", cdo_ver))
 
 rocoto_ver=os.getenv("rocoto_ver") or "1.3.3"
-load(pathJoin("rocoto", rocoto_ver))
+load("rocoto")
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")

--- a/modulefiles/hafs.orion.lua
+++ b/modulefiles/hafs.orion.lua
@@ -118,7 +118,7 @@ cdo_ver=os.getenv("cdo_ver") or "1.9.10"
 load(pathJoin("cdo", cdo_ver))
 
 rocoto_ver=os.getenv("rocoto_ver") or "1.3.3"
-load(pathJoin("rocoto", rocoto_ver))
+load("rocoto")
 
 setenv("CMAKE_C_COMPILER", "mpiicc")
 setenv("CMAKE_CXX_COMPILER", "mpiicpc")


### PR DESCRIPTION
**Description**

It was reccomended by Jet Admin to use the latest default version of Rocoto, rather than a specific version, as certain versions failed to track the status of the workflow with the Slurm upgrade on RDHPCS platforms(Issue https://github.com/hafs-community/HAFS/issues/254)

The following changes are included in this PR.

- The application level modulefiles for Hera/Orion/Jet were modified to use the default version of Rocoto


## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [x] Jet
- [x] Hera
- [x] Orion

