### PR TITLE
FV3_HRRR_gf (RRFS physics) support mostly works

### DIFF
--- a/parm/hafs_hrrr_gf.conf
+++ b/parm/hafs_hrrr_gf.conf
@@ -1,6 +1,5 @@
 [config]
 RUN=hrfs
-run_wave=yes
 
 [atm_init]
 ccpp_suite_regional_init=FV3_HRRR_gf
@@ -12,6 +11,11 @@ ccpp_suite_nest_init=FV3_HRRR_gf
 ccpp_suite_regional=FV3_HRRR_gf
 ccpp_suite_glob=FV3_HRRR_gf
 ccpp_suite_nest=FV3_HRRR_gf
+
+write_tasks_per_group=120
+write_groups=2
+atm_tasks=1200
+all_tasks=1260 ;; 960 fv3, 240 write, 60 ocean/med
 
 bl_mynn_edmf=1
 bl_mynn_edmf_mom=1
@@ -40,5 +44,7 @@ lsoil_lsm=9 ;; number of soil layers internal to land surface model; -1 use lsoi
 progsigma=.false.
 satmedmf=.false.
 shal_cnv=.true.
+sfclay_compute_flux=.true.
+sedi_semi=.false.,.false.
 
 gwd_opt=3

--- a/rocoto/HRRRGF-mom6-ww3.sh
+++ b/rocoto/HRRRGF-mom6-ww3.sh
@@ -7,12 +7,12 @@ set -x
 
 cd ${HOMEhafs}/rocoto
 EXPT=$(basename ${HOMEhafs})
-SUBEXPT=HRRRGF-atm4-nmlfix
+SUBEXPT=HRRRGF-mom6-ww3
 conf=../parm/hafs_hrrr_gf.conf
 opts="-t -f"
 
 first_test_works='2023082618-2023082700 10L'
-breaks_noahmp='2020082506-2020082606 13L'
+breaks_noahmp='2020082506-2020082618 13L'
 
 scrubopt="config.scrub_work=no config.scrub_com=no"
 ./run_hafs.py ${opts} ${breaks_noahmp} HISTORY \
@@ -20,7 +20,7 @@ scrubopt="config.scrub_work=no config.scrub_com=no"
     config.NHRS=24 ${scrubopt} \
     ../parm/hafs_hrrr_gf.conf \
     forecast.atm_tasks=1200 \
-    forecast.all_tasks=1200 \
+    forecast.all_tasks=1320 \
     gsi.use_bufr_nr=yes \
-    config.run_wave=no \
-    config.run_ocean=no
+    config.run_wave=yes \
+    config.run_ocean=yes

--- a/scripts/exhafs_forecast.sh
+++ b/scripts/exhafs_forecast.sh
@@ -1258,7 +1258,7 @@ cd ..
 # Prepare diag_table, field_table, input.nml, input_nest02.nml, model_configure, and ufs.configure
 ${NCP} ${PARMforecast}/diag_table.tmp .
 if [ ${imp_physics:-11} = 8 ]; then
-  ${NCP} ${PARMforecast}/field_table_thompson ./field_table
+  ${NCP} ${PARMforecast}/field_table_thompson_aero ./field_table
 else
   ${NCP} ${PARMforecast}/field_table .
 fi

--- a/ush/hafs/namelist.py
+++ b/ush/hafs/namelist.py
@@ -221,11 +221,11 @@ class NamelistInserter(object):
 
     ## @var nlfalse
     #  regular expression that matches false values
-    nlfalse=re.compile('\A(?i)(?:f.*|.false.|n|no|0*[1-9][0-9]*)\Z')
+    nlfalse=re.compile('(?i)\A(?:f.*|.false.|n|no|0*[1-9][0-9]*)\Z')
 
     ## @var nltrue
     #  regular expression that matches true values
-    nltrue=re.compile('\A(?i)(?:t.*|.true.|y|yes|0)\Z')
+    nltrue=re.compile('(?i)\A(?:t.*|.true.|y|yes|0)\Z')
 
     ## @var comment
     #  regular expression that matches comments
@@ -483,12 +483,12 @@ physics.bl_pbl_physics=3'''
 
     ##@var nlfalse
     # detects false Fortran logical constants
-    nlfalse=re.compile('\A(?i)(?:f.*|.false.)\Z')
+    nlfalse=re.compile('(?i)\A(?:f.*|.false.)\Z')
     """A regular expression from re.compile, to detect false Fortran logical values."""
 
     ##@var nltrue
     # detects true Fortran logical constants
-    nltrue=re.compile('\A(?i)(?:t.*|.true.)\Z')
+    nltrue=re.compile('(?i)\A(?:t.*|.true.)\Z')
     """A regular expression from re.compile, to detect true Fortran logical values."""
 
     ##@var TRAIT


### PR DESCRIPTION
## Description of changes
Adds support for FV3_HRRR_gf suite. It nearly always works now.

The one time it doesn't work is the 2020082518 cycle of 13L. If you set the forecast length to 24 hours, it'll run to 24 hours, and abort during model finalization with a NaN. Instead, if you set the forecast length above 24 hours, or below 23 hours, and it'll run just fine.

This PR is mostly to let @mrinalbiswas start testing the configuration.

Also, there are some bug fixes to the ww3 initialization. Some regular expressions used a syntax that isn't supported in Python 3.11 and newer.

## Issues addressed (optional)
N/A

## Dependencies (optional)
If submodule PRs are required, please link them below. For example:
- https://github.com/hafs-community/ufs-weather-model/pull/10

## Contributors (optional)
Development thus far has mostly been me, but I do have some bug fixes from @mrinalbiswas.

## Tests conducted
Only tested on Hercules, since that's where our resources are.

Ran 2020 13L cycles 2020082506 through 2020082618 with mom6 and ww3 coupling. All cycles worked except the one mentioned earlier. The `rocoto/HRRRGF-mom6-ww3.sh` will reproduce this bug.

Also ran 2023 10L, cycles 2023082618-2023082700 with no error. Succeeded uncoupled, and also coupled with mom6+ww3.

## Application-level regression test status
None yet; @mrinalbiswas is working on this.