### PR TITLE
switch thompson field table aerosol based on ltaerosol

### DIFF
--- a/parm/forecast/regional/field_table_thompson_aero
+++ b/parm/forecast/regional/field_table_thompson_aero
@@ -1,0 +1,65 @@
+# added by FRE: sphum must be present in atmos
+# specific humidity for moist runs
+ "TRACER", "atmos_mod", "sphum"
+           "longname",     "specific humidity"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=3.e-6" /
+# prognostic cloud water mixing ratio
+ "TRACER", "atmos_mod", "liq_wat"
+           "longname",     "cloud water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic ice water mixing ratio
+ "TRACER", "atmos_mod", "ice_wat"
+           "longname",     "cloud ice mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic rain water mixing ratio
+ "TRACER", "atmos_mod", "rainwat"
+           "longname",     "rain water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic snow water mixing ratio
+ "TRACER", "atmos_mod", "snowwat"
+           "longname",     "snow water mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic Grau water mixing ratio
+ "TRACER", "atmos_mod", "graupel"
+           "longname",     "graupel mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# prognostic cloud water number concentration - not for non-aerosol runs
+"TRACER", "atmos_mod", "water_nc"
+          "longname",     "cloud  liquid water  number concentration"
+          "units",        "/kg"
+      "profile_type", "fixed", "surface_value=0.0" /
+# prognostic cloud ice number concentration
+ "TRACER", "atmos_mod", "ice_nc"
+           "longname",     "cloud ice water number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic rain number concentration
+ "TRACER", "atmos_mod", "rain_nc"
+           "longname",     "rain number concentration"
+           "units",        "/kg"
+       "profile_type", "fixed", "surface_value=0.0" /
+# prognostic ozone mixing ratio tracer
+ "TRACER", "atmos_mod", "o3mr"
+           "longname",     "ozone mixing ratio"
+           "units",        "kg/kg"
+       "profile_type", "fixed", "surface_value=1.e30" /
+# water- and ice-friendly aerosols (Thompson) - not for non-aerosol runs
+"TRACER", "atmos_mod", "liq_aero"
+          "longname",     "water-friendly aerosol number concentration"
+          "units",        "/kg"
+      "profile_type", "fixed", "surface_value=0.0" /
+"TRACER", "atmos_mod", "ice_aero"
+          "longname",     "ice-friendly aerosol number concentration"
+          "units",        "/kg"
+      "profile_type", "fixed", "surface_value=0.0" /
+# prognostic subgrid scale turbulent kinetic energy
+ "TRACER", "atmos_mod", "sgs_tke"
+           "longname",     "subgrid scale turbulent kinetic energy"
+           "units",        "m2/s2"
+       "profile_type", "fixed", "surface_value=0.0" /

--- a/scripts/exhafs_forecast.sh
+++ b/scripts/exhafs_forecast.sh
@@ -937,7 +937,11 @@ cd ..
 # Prepare diag_table, field_table, input.nml, input_nest02.nml, model_configure, and ufs.configure
 ${NCP} ${PARMforecast}/diag_table.tmp .
 if [ ${imp_physics:-11} = 8 ]; then
-  ${NCP} ${PARMforecast}/field_table_thompson_aero ./field_table
+  if [ ${ltaerosol} = .true. ]; then
+    ${NCP} ${PARMforecast}/field_table_thompson_aero ./field_table
+  else
+    ${NCP} ${PARMforecast}/field_table_thompson ./field_table
+  fi
 else
   ${NCP} ${PARMforecast}/field_table .
 fi
@@ -1258,7 +1262,11 @@ cd ..
 # Prepare diag_table, field_table, input.nml, input_nest02.nml, model_configure, and ufs.configure
 ${NCP} ${PARMforecast}/diag_table.tmp .
 if [ ${imp_physics:-11} = 8 ]; then
-  ${NCP} ${PARMforecast}/field_table_thompson_aero ./field_table
+  if [ ${ltaerosol} = .true. ]; then
+    ${NCP} ${PARMforecast}/field_table_thompson_aero ./field_table
+  else
+    ${NCP} ${PARMforecast}/field_table_thompson ./field_table
+  fi
 else
   ${NCP} ${PARMforecast}/field_table .
 fi


### PR DESCRIPTION
## Description of changes
The thompson field table should switch between aerosol and non-aerosol based on the ltaerosol variable.
These changes are untested. @mrinalbiswas (Biswas) will test them shortly.

## Issues addressed (optional)
Email from Biswas.

## Dependencies (optional)
No

## Contributors (optional)
Biswas

## Tests conducted
None. This pull request is to hand over the changes for Biswas to test.