### PR TITLE
emc_graphics: plot_tempanomaly_hgt_wind.py: stormModel must be upper-case

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
     branch = production/hafs.v2
 [submodule "hafs_graphics"]
     path = sorc/hafs_graphics.fd/emc_graphics
-    url = https://github.com/hafs-community/hafs_graphics.git
-    branch = feature/hafs.v2.0.1
+    url = https://github.com/SamuelTrahanNOAA/hafs_graphics.git
+    branch = bugfix/hafs.v2.0.1-upper


### PR DESCRIPTION
## Description of changes
Switches to this PR of emc-graphics to correct a script bug:

- https://github.com/hafs-community/hafs_graphics/pull/14

## Issues addressed (optional)
- https://github.com/hafs-community/hafs_graphics/issues/15

## Dependencies (optional)
- https://github.com/hafs-community/hafs_graphics/pull/14

## Contributors (optional)
@mrinalbiswas 

## Tests conducted
A few cycles of Hurricane Lee

## Application-level regression test status
None yet.