### PR TITLE
add ww3 point list for HAFS

### DIFF
--- a/parm/ww3/regional/ww3_points.list
+++ b/parm/ww3/regional/ww3_points.list
@@ -1,0 +1,835 @@
+$ Global output point data file for global wave ensembles
+$
+$ Retained only deep water buoys or so from general buoy file
+$ taken from multi_1/2
+$
+$ Key to data in file:
+$
+$   LON      Longitude, east positive
+$   LAT      Latitude
+$   NAME     Output point name C*10, no blanks in name allowed
+$   AH       Anemometer height, dummy value for none-data points
+$   TYPE     Buoy type indicator, used for plotting and postprocessing
+$             DAT      Data point
+$             XDT      Former data point
+$             BPT      Boundary data for external models.
+$             VBY      'Virtual buoy'
+$   SOURCE   Source of data point
+$             ENCAN    Environment Canada
+$             GOMOOS   Gulf of Maine OOS
+$             IDT      Irish Department of Transportation
+$             METFR    Meteo France
+$             NCEP     Boundary and other data points
+$             NDBC     National Data Buoy Center
+$             PRIV     Private and incidental data sources
+$             SCRIPPS  Scripps
+$             UKMO     UK Met Office
+$             PDES     Puertos del Estados
+$             SHOM     Service Hydrographique et Oceanographique de la Marine
+$             OCNOR    Fugro Oceanor
+$             WHOI     Woods Hole Oceanographic Institute
+$	      SKOREA   South Korea
+$             MVEW     Ministerie van Verkeer en Waterstaat
+$             CORMP    Coastal Ocean Research and Monitoring Program
+$             DIMAR    Direccion General Maritima (Columbia)
+$             BP       British Petroleum
+$   SCALE    Scale indicator for plotting of locations on map
+$            Point will only be plotted if SCALE =< DX in our
+$            GrADS scripts, DX is width of plot in logitude
+$
+$   DEptH    Depth in meters
+$
+$ Notes:
+$
+$  - The '$' at the first position identifies comments for WAVEWATCH III
+$    input.
+$  - The first three data columns are used by the forecats code, the other
+$    are used by postprocessing scripts.
+$
+$ NE Pacific deep ocean
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+  -148.02   56.31  '46001     '   5.0   DAT  NDBC     360
+  -130.27   42.60  '46002     '   5.0   DAT  NDBC     360
+  -136.10   50.93  '46004     '   5.0   DAT  ENCAN    360
+  -131.02   46.05  '46005     '   5.0   DAT  NDBC     360
+  -137.48   40.80  '46006     '   5.0   DAT  NDBC     360
+  -177.58   57.05  '46035     '  10.0   DAT  NDBC     360
+  -133.94   48.35  '46036     '   5.0   DAT  ENCAN    360
+  -130.00   37.98  '46059     '   5.0   DAT  NDBC     360
+  -154.98   52.70  '46066     '   5.0   DAT  NDBC     360
+   175.28   55.00  '46070     '   5.0   DAT  NDBC     360
+  -172.03   54.94  '46073     '  10.0   DAT  NDBC     360
+  -138.85   53.91  '46184     '   5.0   DAT  ENCAN    360
+$
+$ NE Pacific coastal
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+$ Alaska
+$
+  -146.83   60.22  '46061     '   5.0   DAT  NDBC      90
+   179.05   51.16  '46071     '   5.0   DAT  NDBC     360
+  -171.73   52.25  '46072     '   5.0   DAT  NDBC     360
+  -160.81   53.93  '46075     '   5.0   DAT  NDBC     360
+  -148.00   59.50  '46076     '   5.0   DAT  NDBC     360
+  -152.45   56.05  '46078     '   5.0   DAT  NDBC     360
+  -152.09   59.76  '46106     '   999   DAT  NDBC     75
+  -150.00   58.00  '46080     '   5.0   DAT  NDBC     360
+  -143.42   59.69  '46082     '   5.0   DAT  NDBC     360
+  -138.00   58.25  '46083     '   5.0   DAT  NDBC     360
+  -136.16   56.59  '46084     '   5.0   DAT  NDBC     360
+  -142.56   56.85  '46085     '   5.0   DAT  NDBC     360
+$
+$ Canada
+$
+  -127.93   49.74  '46132     '   5.0   DAT  ENCAN     90
+  -132.45   54.38  '46145     '   5.0   DAT  ENCAN     45
+  -131.22   51.83  '46147     '   5.0   DAT  ENCAN     90
+  -131.10   53.62  '46183     '   5.0   DAT  ENCAN     45
+  -129.81   52.42  '46185     '   5.0   DAT  ENCAN     45
+  -128.75   51.37  '46204     '   5.0   DAT  ENCAN     45
+  -134.28   54.16  '46205     '   5.0   DAT  ENCAN     45
+  -126.00   48.84  '46206     '   5.0   DAT  ENCAN     45
+  -129.92   50.87  '46207     '   5.0   DAT  ENCAN     45
+  -132.68   52.52  '46208     '   5.0   DAT  ENCAN     45
+$
+$ USA
+$
+  -120.87   34.88  '46011     '   5.0   DAT  NDBC      15
+  -122.88   37.36  '46012     '   5.0   DAT  NDBC      45
+  -123.32   38.23  '46013     '   5.0   DAT  NDBC      25
+  -123.97   39.22  '46014     '   5.0   DAT  NDBC      45
+  -124.85   42.75  '46015     '   5.0   DAT  NDBC      45
+  -124.54   40.78  '46022     '   5.0   DAT  NDBC      25
+  -120.97   34.71  '46023     '  10.0   DAT  NDBC      45
+  -119.08   33.75  '46025     '   5.0   DAT  NDBC      45
+  -122.82   37.75  '46026     '   5.0   DAT  NDBC      25
+  -124.38   41.85  '46027     '   5.0   DAT  NDBC      45
+  -121.89   35.74  '46028     '   5.0   DAT  NDBC      45
+  -124.51   46.12  '46029     '   5.0   DAT  NDBC      45
+  -124.53   40.42  '46030     '   5.0   DAT  NDBC      15
+  -124.75   47.34  '46041     '   5.0   DAT  NDBC      45
+  -122.42   36.75  '46042     '   5.0   DAT  NDBC      45
+  -119.53   32.43  '46047     '   5.0   DAT  NDBC      45
+  -124.53   44.62  '46050     '   5.0   DAT  NDBC      45
+  -119.85   34.24  '46053     '   5.0   DAT  NDBC      45
+  -120.45   34.27  '46054     '  10.0   DAT  NDBC      25
+  -121.01   35.10  '46062     '   5.0   DAT  NDBC      45
+  -120.70   34.27  '46063     '   5.0   DAT  NDBC      45
+  -120.20   33.65  '46069     '   5.0   DAT  NDBC      45
+  -118.00   32.50  '46086     '   5.0   DAT  NDBC      45
+  -124.73   48.49  '46087     '   5.0   DAT  NDBC      45
+  -125.77   45.88  '46089     '   5.0   DAT  NDBC      45
+  -152.00   59.72  '46108     '   5.0   DAT  NDBC      45
+  -124.24   46.86  '46211     '  999.   DAT  SCRIPPS   25
+$  -124.31   40.75  '46212     '  999.   DAT  SCRIPPS   25
+  -124.74   40.29  '46213     '  999.   DAT  SCRIPPS   25
+  -123.47   37.95  '46214     '  999.   DAT  SCRIPPS   45
+  -120.86   35.20  '46215     '  999.   DAT  SCRIPPS   45
+  -119.80   34.33  '46216     '  999.   DAT  SCRIPPS   15
+  -119.43   34.17  '46217     '  999.   DAT  SCRIPPS   15
+  -120.78   34.45  '46218     '  999.   DAT  SCRIPPS   25
+  -119.88   33.22  '46219     '  999.   DAT  SCRIPPS   45
+  -118.63   33.85  '46221     '  999.   DAT  SCRIPPS   15
+  -118.32   33.62  '46222     '  999.   DAT  SCRIPPS   15
+  -117.77   33.46  '46223     '  999.   DAT  SCRIPPS   15
+  -117.47   33.18  '46224     '  999.   DAT  SCRIPPS   15
+  -117.39   32.93  '46225     '  999.   DAT  SCRIPPS   15
+  -117.44   32.63  '46227     '  999.   DAT  SCRIPPS   15
+  -124.55   43.77  '46229     '  999.   DAT  SCRIPPS   25
+  -117.37   32.75  '46231     '  999.   DAT  SCRIPPS   15
+  -117.33   32.43  '46232     '  999.   DAT  SCRIPPS   15
+  -121.95   36.76  '46236     '  999.   DAT  SCRIPPS   15
+  -122.60   37.78  '46237     '  999.   DAT  SCRIPPS   15
+  -119.47   33.40  '46238     '  999.   DAT  SCRIPPS   15
+  -122.10   36.34  '46239     '  999.   DAT  SCRIPPS   15
+  -121.91   36.62  '46240     '  999.   DAT  SCRIPPS   15
+  -124.13   46.22  '46243     '  999.   DAT  SCRIPPS   45
+  -124.36   40.89  '46244     '  999.   DAT  SCRIPPS   45
+  -149.09   49.98  '46246     '  999.   DAT  SCRIPPS   45
+  -124.67   46.13  '46248     '  999.   DAT  SCRIPPS   45
+$
+  -117.75   32.64  'SGX01     '  999.   VBY  NCEP      25
+  -116.48   23.62  'EFT1      '  999.   VBY  NCEP      25
+$
+$ South America
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -77.50    6.26  '32488     '  999.   DAT  DIMAR     45
+   -77.74    3.52  '32487     '  999.   DAT  DIMAR     45
+   -72.22   12.35  '41193     '  999.   DAT  DIMAR    120
+$
+$ Japanese buoys
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   134.90   28.90  '21004     '   999.  XDT  JAPAN    360
+   126.30   28.10  '22001     '   999.  XDT  JAPAN    360
+$
+$ South Korean buoys
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   126.02   37.23  '22101     '   999.  DAT  SKOREA    100
+   125.77   34.80  '22102     '   999.  DAT  SKOREA    100
+   127.50   34.00  '22103     '   999.  DAT  SKOREA    100
+   128.90   34.77  '22104     '   999.  DAT  SKOREA    100
+   130.00   37.53  '22105     '   999.  DAT  SKOREA    100
+   129.78   36.35  '22106     '   999.  DAT  SKOREA    100
+   126.33   33.00  '22107     '   999.  DAT  SKOREA    100
+$
+$ Hawaii
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+  -162.21   23.43  '51001     '   5.0   DAT  NDBC     360
+  -157.78   17.19  '51002     '   5.0   DAT  NDBC     360
+  -160.82   19.22  '51003     '   5.0   DAT  NDBC     360
+  -152.48   17.52  '51004     '   5.0   DAT  NDBC     360
+  -154.06   23.55  '51000     '   5.0   DAT  NDBC      11
+  -153.90   23.56  '51100     '   5.0   DAT  NDBC      11
+  -162.06   24.32  '51101     '   5.0   DAT  NDBC      11
+  -158.12   21.67  '51201     '  999.   DAT  SCRIPPS   11
+  -157.68   21.42  '51202     '  999.   DAT  SCRIPPS   11
+  -157.00   20.79  '51203     '  999.   DAT  SCRIPPS   11
+  -158.12   21.28  '51204     '  999.   DAT  SCRIPPS   11
+  -156.42   21.02  '51205     '  999.   DAT  SCRIPPS   11
+  -154.97   19.78  '51206     '  999.   DAT  SCRIPPS   11
+  -157.75   21.48  '51207     '  999.   DAT  SCRIPPS   11
+  -159.574  22.285 '51208     '  999.   DAT  SCRIPPS   11
+$
+  -158.00   24.00  'HNL01     '  999.   VBY  NCEP     360
+  -153.00   22.50  'HNL02     '  999.   VBY  NCEP     360
+  -157.75   22.00  'HNL10     '  999.   VBY  NCEP      45
+  -158.25   21.00  'HNL11     '  999.   VBY  NCEP      45
+  -156.50   19.75  'HNL12     '  999.   VBY  NCEP      45
+$
+$ Other deep Pacific
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+  -153.87    0.02  '51028     '   5.0   DAT  NDBC     360
+   144.79   13.35  '52200     '  999.   DAT  SCRIPPS  360
+   171.40    7.09  '52201     '  999.   DAT  SCRIPPS  360
+   144.80   13.68  '52202     '  999.   DAT  SCRIPPS  360
+   145.66   15.27  '52211     '  999.   DAT  SCRIPPS  360
+$
+$ NWS forecast points
+$
+   143.75   12.00  'GUAM      '  999.   VBY  NCEP     360
+   147.50   16.00  'SAIPAN    '  999.   VBY  NCEP     360
+   145.00   14.70  'SAIPAN_W  '  999.   VBY  NCEP     360
+   145.60   14.30  'SAIPAN_E  '  999.   VBY  NCEP     360
+   166.50   19.50  'WAKE      '  999.   VBY  NCEP     360
+   136.25    9.00  'PALAU     '  999.   VBY  NCEP     360
+   133.90    7.50  'PALAU_W   '  999.   VBY  NCEP     360
+   134.90    7.70  'PALAU_E   '  999.   VBY  NCEP     360
+   138.00    9.60  'YAP       '  999.   VBY  NCEP     360
+   138.40    9.60  'YAP_E     '  999.   VBY  NCEP     360
+   152.50    8.00  'CHUUK     '  999.   VBY  NCEP     360
+   151.20    7.40  'CHUUK_W   '  999.   VBY  NCEP     360
+   152.10    7.60  'CHUUK_E   '  999.   VBY  NCEP     360
+   157.50    7.00  'POHNPEI   '  999.   VBY  NCEP     360
+   158.40    7.10  'POHNPEI_E '  999.   VBY  NCEP     360
+   163.00    5.10  'KOSRAE    '  999.   VBY  NCEP     360
+   162.80    5.90  'KOSRAE_W  '  999.   VBY  NCEP     360
+   167.80    9.50  'KWAJALEIN '  999.   VBY  NCEP     360
+   167.50    8.67  'KWAJ_W1   '  999.   VBY  NCEP     360
+   167.00    8.67  'KWAJ_W2   '  999.   VBY  NCEP     360
+   168.17    8.67  'KWAJ_E    '  999.   VBY  NCEP     360
+   166.33    9.17  'WOTHO     '  999.   VBY  NCEP     360
+   168.00    9.17  'ROI_NAMUR '  999.   VBY  NCEP     360
+   171.50    9.17  'WOTJE_E   '  999.   VBY  NCEP     360
+   146.25  -12.00  'NEWGUINE_S'  999.   VBY  NCEP     360
+   171.25    8.00  'MAJURO    '  999.   VBY  NCEP     360
+   171.40    7.60  'MAJURO_02 '  999.   VBY  NCEP     360
+   171.50    6.60  'MAJURO_03 '  999.   VBY  NCEP     360
+   163.75   13.00  'ENEWETAK  '  999.   VBY  NCEP     360
+  -168.75  -15.00  'PAGO_PAGO '  999.   VBY  NCEP     360
+$
+$ Pacific training points
+$
+  -177.40   28.20  'MIDWAY    '  999.   VBY  NCEP     360
+  -169.50   16.70  'JOHNSTON  '  999.   VBY  NCEP     360
+   176.25  -18.00  'NADI      '  999.   VBY  NCEP     360
+   179.20   -8.50  'FUNAFUTI  '  999.   VBY  NCEP     360
+  -175.00  -22.00  'TONGATAPU '  999.   VBY  NCEP     360
+  -159.80  -21.20  'RAROTONGA '  999.   VBY  NCEP     360
+   167.50  -24.00  'NOUMEA    '  999.   VBY  NCEP     360
+   167.50  -18.00  'PORT_VILA '  999.   VBY  NCEP     360
+  -149.60  -19.00  'PAPEETE   '  999.   VBY  NCEP     360
+   174.00    1.00  'TARAWA    '  999.   VBY  NCEP     360
+  -169.90  -19.10  'NIUE      '  999.   VBY  NCEP     360
+  -166.30   23.90  'FF_SHOALS '  999.   VBY  NCEP     360
+   167.00   -0.50  'NAURU     '  999.   VBY  NCEP     360
+  -171.90   -9.20  'NUKUNONO  '  999.   VBY  NCEP     360
+   160.00  -12.00  'SOLOMON_SW'  999.   VBY  NCEP     360
+   165.00  -12.00  'SOLOMON_SE'  999.   VBY  NCEP     360
+   160.00   -5.00  'SOLOMON_N '  999.   VBY  NCEP     360
+$
+$ Virtual points for Indonesia
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+$
+   102.00   -5.00  'P_ENGGANO '  999.   VBY  NCEP     360
+   107.00    0.00  'P_PENJAN  '  999.   VBY  NCEP     360
+   110.00   -5.00  'SEMARANG  '  999.   VBY  NCEP     360
+   122.00  -11.00  'P_SAWA    '  999.   VBY  NCEP     360
+   132.00    1.00  'P_IGI     '  999.   VBY  NCEP     360
+   133.00   -8.00  'P_JAMDENA '  999.   VBY  NCEP     360
+    93.00    6.00  'G_NICOBAR '  999.   VBY  NCEP     360
+   100.00    4.00  'P_PANGKOR '  999.   VBY  NCEP     100
+   118.00   -1.00  'SULAWESI  '  999.   VBY  NCEP     360
+   120.00   -7.50  'P_BONARAT '  999.   VBY  NCEP     100
+   125.00   -5.00  'P_RUNDUMA '  999.   VBY  NCEP     100
+   123.00    3.00  'BORNEO    '  999.   VBY  NCEP     360
+   126.00    1.00  'P_GUREDA  '  999.   VBY  NCEP     100
+$
+$ Virtual points for Malaysia
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+$
+   104.00    6.00  'MALAY01   '  999.   VBY  NCEP     100
+   105.00    3.00  'MALAY02   '  999.   VBY  NCEP     100
+   110.00    3.00  'MALAY03   '  999.   VBY  NCEP     100
+   113.00    5.00  'MALAY04   '  999.   VBY  NCEP     100
+   116.00    7.50  'MALAY05   '  999.   VBY  NCEP     100
+   117.00    7.50  'MALAY06   '  999.   VBY  NCEP     100
+$
+$ Gulf of America and Caribbean Sea
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -89.67   25.90  '42001     '  10.0   DAT  NDBC     360
+   -94.42   25.17  '42002     '  10.0   DAT  NDBC     360
+   -85.94   26.07  '42003     '  10.0   DAT  NDBC     360
+   -88.77   30.09  '42007     '   5.0   DAT  NDBC      90
+   -95.36   27.91  '42019     '   5.0   DAT  NDBC      90
+   -96.70   26.94  '42020     '   5.0   DAT  NDBC      90
+   -94.40   29.22  '42035     '   5.0   DAT  NDBC      90
+   -84.52   28.50  '42036     '   5.0   DAT  NDBC      90
+   -92.55   27.42  '42038     '   5.0   DAT  NDBC      90
+   -86.02   28.79  '42039     '   5.0   DAT  NDBC      90
+   -87.55   30.06  '42012     '   5.0   DAT  NDBC      90
+   -88.21   29.18  '42040     '   5.0   DAT  NDBC      90
+   -90.46   27.50  '42041     '   5.0   DAT  NDBC      90
+   -88.49   28.19  '42887     '  48.2   DAT  BP        90
+$
+   -87.73   26.00  '42054     '  10.0   XDT  NDBC     360
+   -94.05   22.01  '42055     '  10.0   DAT  NDBC     360
+   -85.06   19.87  '42056     '  10.0   DAT  NDBC     360
+   -81.50   16.83  '42057     '  10.0   DAT  NDBC     360
+   -75.06   15.09  '42058     '  10.0   DAT  NDBC     360
+   -81.95   24.39  '42080     ' 999.    DAT  NDBC      45
+   -84.24   27.34  '42099     ' 999.    DAT  SCRIPPS  100
+$
+   -67.50   15.01  '42059     '   5.0   DAT  NDBC     360
+   -63.50   16.50  '42060     '   5.0   DAT  NDBC     360
+$
+   -53.08   14.55  '41040     '   5.0   DAT  NDBC     360
+   -46.00   14.53  '41041     '   5.0   DAT  NDBC     360
+   -57.90   15.90  '41100     '   5.0   DAT  METFR    360
+   -56.20   14.60  '41101     '   5.0   DAT  METFR    360
+$
+   -81.75   24.00  'EYW01     '  999.   VBY  NCEP      90
+   -82.25   25.00  'EYW02     '  999.   VBY  NCEP      90
+$
+   -66.50   19.00  'PUERTO_R_N'  999.   VBY  NCEP      90
+   -66.50   17.50  'PUERTO_R_S'  999.   VBY  NCEP      90
+   -67.50   19.00  'CARCOOS01 '  999.   VBY  NCEP      90
+   -65.50   19.00  'CARCOOS02 '  999.   VBY  NCEP      90
+   -64.00   19.00  'CARCOOS03 '  999.   VBY  NCEP      90
+   -64.40   17.30  'CARCOOS04 '  999.   VBY  NCEP      90
+   -67.50   17.50  'CARCOOS05 '  999.   VBY  NCEP      90
+$
+$ NW Atlantic deep ocean
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -72.66   34.68  '41001     '   5.0   DAT  NDBC     360
+   -75.36   32.32  '41002     '   5.0   DAT  NDBC     360
+   -79.09   32.50  '41004     '   5.0   DAT  NDBC     360
+   -80.87   31.40  '41008     '   5.0   DAT  NDBC     360
+   -66.58   41.11  '44011     '   5.0   DAT  NDBC     360
+   -62.00   42.26  '44137     '   5.0   DAT  ENCAN    360
+   -53.62   44.26  '44138     '   5.0   DAT  ENCAN    360
+   -57.08   44.26  '44139     '   5.0   DAT  ENCAN    360
+   -51.74   43.75  '44140     '   5.0   DAT  ENCAN    360
+   -58.00   43.00  '44141     '   5.0   DAT  ENCAN    360
+   -64.02   42.50  '44142     '   5.0   DAT  ENCAN    360
+   -64.01   42.50  '44150     '   5.0   DAT  ENCAN    360
+   -48.01   46.77  'WRB07     '  10.0   DAT  PRIV     360
+$
+$ NW Atlantic coastal
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -80.17   28.50  '41009     '   5.0   DAT  NDBC      80
+   -78.47   28.95  '41010     '   5.0   DAT  NDBC      80
+   -80.60   30.00  '41012     '   5.0   DAT  NDBC      80
+   -77.74   33.44  '41013     '   5.0   DAT  NDBC      80
+   -75.40   35.01  '41025     '   5.0   DAT  NDBC      80
+   -77.28   34.48  '41035     '   5.0   DAT  NDBC      80
+   -76.95   34.21  '41036     '   5.0   DAT  NDBC      80
+   -77.36   33.99  '41037     '   3.0   DAT  CORMP     80
+   -77.72   34.14  '41038     '   3.0   DAT  CORMP     80
+   -65.01   20.99  '41043     '   5.0   DAT  NDBC      90
+   -70.99   24.00  '41046     '   5.0   DAT  NDBC      90
+   -71.49   27.47  '41047     '  10.0   DAT  NDBC      90
+   -69.65   31.98  '41048     '  10.0   DAT  NDBC      90
+   -63.00   27.50  '41049     '   5.0   DAT  NDBC      90
+   -58.69   21.65  '41044     '   5.0   DAT  NDBC      90
+   -77.30   34.48  '41109     '   3.0   DAT  CORMP     80
+   -77.71   34.14  '41110     '   3.0   DAT  CORMP     80
+   -67.28   18.38  '41111     '   3.0   DAT  CORMP     80
+   -81.29   30.72  '41112     '  999.   DAT  SCRIPPS   30
+   -80.53   28.40  '41113     '  999.   DAT  SCRIPPS   30
+   -80.22   27.55  '41114     '  999.   DAT  SCRIPPS   30
+$
+$   -75.72   36.20  '44056     '  999.   DAT  USACE     90
+   -75.78   36.91  '44099     '  999.   DAT  SCRIPPS   90
+   -75.59   36.26  '44100     '  999.   DAT  SCRIPPS   90
+   -70.43   38.48  '44004     '   5.0   DAT  NDBC      90
+   -69.16   43.19  '44005     '   5.0   DAT  NDBC      90
+   -69.43   40.50  '44008     '   5.0   DAT  NDBC      90
+   -74.70   38.46  '44009     '   5.0   DAT  NDBC      90
+   -74.84   36.61  '44014     '   5.0   DAT  NDBC      90
+   -72.10   40.70  '44017     '   5.0   DAT  NDBC      80
+   -71.01   41.38  '44070     '  999.   DAT  NDBC      60
+   -69.29   41.26  '44018     '   5.0   DAT  NDBC      80
+   -72.60   39.58  '44066     '   5.0   DAT  NDBC      80
+   -65.93   42.31  '44024     '   4.0   DAT  GOMOOS    80
+   -73.17   40.25  '44025     '   5.0   DAT  NDBC      80
+   -75.492  36.872 '44093     '  999.   DAT  SCRIPPS   80
+   -75.33   35.75  '44095     '  999.   DAT  SCRIPPS   80
+   -75.81   36.02  '44096     '  999.   DAT  SCRIPPS   80
+   -71.12   40.98  '44097     '  999.   DAT  SCRIPPS   80
+   -70.17   42.80  '44098     '  999.   DAT  SCRIPPS   80
+   -67.31   44.27  '44027     '   5.0   DAT  NDBC      80
+   -67.88   43.49  '44037     '   4.0   DAT  GOMOOS    80
+   -66.55   43.62  '44038     '   4.0   DAT  GOMOOS    80
+$
+   -53.39   46.44  '44251     '   5.0   DAT  ENCAN     80
+   -57.35   47.28  '44255     '   5.0   DAT  ENCAN     80
+$
+   -70.25   42.50  'BOX01     '  999.   VBY  NCEP      45
+   -67.50   44.00  'CAR01     '  999.   VBY  NCEP      45
+   -77.00   30.75  'CHS01     '  999.   VBY  NCEP      80
+   -69.75   43.25  'GYX01     '  999.   VBY  NCEP      45
+   -77.00   34.00  'ILM01     '  999.   VBY  NCEP      45
+   -78.50   33.25  'ILM02     '  999.   VBY  NCEP      45
+   -80.25   29.50  'JAX02     '  999.   VBY  NCEP      90
+   -79.50   27.25  'MLB01     '  999.   VBY  NCEP      90
+   -79.50   26.25  'MIA01     '  999.   VBY  NCEP      80
+   -79.75   25.00  'MIA02     '  999.   VBY  NCEP      90
+$
+$ NE Atlantic
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+$
+    -5.00   45.20  '62001     '   3.0   DAT  UKMO     360
+   -20.00   41.60  '62002     '  999.   DAT  UNKNOWN  360
+   -12.40   48.70  '62029     '   3.0   DAT  UKMO     360
+    -7.90   51.40  '62023     '  999.   DAT  UNKNOWN  360
+    -5.60   48.50  '62052     '  999.   DAT  METFR    100
+$    -1.45   44.65  '62064     '  999.   DAT  SHOM     100
+   -13.30   51.00  '62081     '   3.0   DAT  UKMO     360
+   -11.20   53.13  '62090     '   4.5   DAT  IDT      100
+    -5.42   53.47  '62091     '   4.5   DAT  IDT       60
+   -10.55   51.22  '62092     '   4.5   DAT  IDT      100
+    -9.07   54.67  '62093     '   4.5   DAT  IDT       60
+    -6.70   51.69  '62094     '   4.5   DAT  IDT       60
+   -15.92   53.06  '62095     '   4.5   DAT  IDT      100
+    -2.90   49.90  '62103     '  14.0   DAT  UKMO     360
+   -12.36   54.54  '62105     '   3.0   DAT  UKMO     360
+    -9.90   57.00  '62106     '   4.5   DAT  UKMO     360
+    -6.10   50.10  '62107     '  14.0   DAT  UKMO     360
+   -19.50   53.50  '62108     '   3.0   DAT  UKMO     360
+    -8.50   47.50  '62163     '   3.0   DAT  UKMO     360
+    -4.70   52.30  '62301     '   3.0   DAT  UKMO      25
+    -5.10   51.60  '62303     '   3.0   DAT  UKMO      25
+     0.00   50.40  '62305     '  14.0   DAT  UKMO      25
+     2.00   51.40  '62170     ' 999.0   DAT  UKMO      25
+   -11.40   59.10  '64045     '   3.0   DAT  UKMO     360
+    -4.50   60.70  '64046     '   3.0   DAT  UKMO     360
+$
+$ Iceland
+$
+    -9.26   68.48  '64071     '  999.   DAT  UNKNOWN   60
+   -23.10   64.05  'TFGSK     '  999.   DAT  UNKNOWN   60
+   -25.00   65.69  'TFBLK     '  999.   DAT  UNKNOWN   60
+$  -23.36   66.44  'TFSTD     '  999.   DAT  UNKNOWN   60
+$  -21.12   65.76  'TFDRN     '  999.   DAT  UNKNOWN   60
+   -18.20   66.50  'TFGRS     '  999.   DAT  UNKNOWN   60
+   -13.50   65.65  'TFKGR     '  999.   DAT  UNKNOWN   60
+   -15.20   64.00  'TFHFN     '  999.   DAT  UNKNOWN   60
+   -20.35   63.00  'TFSRT     '  999.   DAT  UNKNOWN   60
+$  -22.46   63.82  'TFGRV     '  999.   DAT  UNKNOWN   60
+$
+$ Norwegian Sea
+$
+     7.80   64.30  'LF3F      '  999.   DAT  UNKNOWN  360
+     7.30   65.30  'LF3N      '  999.   DAT  UNKNOWN   60
+     8.10   66.00  'LF5T      '  999.   DAT  UNKNOWN  360
+     2.00   66.00  'LDWR      '  999.   DAT  UNKNOWN  360
+$
+$ North Sea
+$
+     1.10   55.30  '62026     '  999.   DAT  UNKNOWN  360
+     0.00   57.00  '62109     '  999.   DAT  UNKNOWN   25
+     0.40   58.10  '62111     '  999.   DAT  UNKNOWN   25
+     1.30   58.70  '62112     '  999.   DAT  UNKNOWN   25
+     1.40   57.70  '62116     '  999.   DAT  UNKNOWN  360
+     0.00   57.90  '62117     '  999.   DAT  UNKNOWN   15
+     0.90   57.70  '62118     '  999.   DAT  UNKNOWN   15
+     2.00   57.00  '62119     '  999.   DAT  UNKNOWN   25
+$    -3.50   53.80  '62125     '  999.   DAT  PRIV      25
+$    -3.60   53.90  '62126     '  999.   DAT  UNKNOWN   25
+$    -3.80   54.00  '62135     '  999.   DAT  UNKNOWN   25
+     1.40   58.70  '62128     '  999.   DAT  UNKNOWN   25
+     2.00   56.40  '62132     '  999.   DAT  UNKNOWN   25
+     1.00   57.10  '62133     '  999.   DAT  UNKNOWN   15
+     2.10   53.00  '62142     '  999.   DAT  PRIV      30
+     1.80   57.70  '62143     '  999.   DAT  UNKNOWN   25
+     1.70   53.40  '62144     '  999.   DAT  PRIV      45
+     2.80   53.10  '62145     '  999.   DAT  PRIV     360
+     2.10   57.10  '62146     '  999.   DAT  UNKNOWN   25
+     1.80   57.00  '62152     '  999.   DAT  UNKNOWN   25
+     0.50   57.40  '62162     '  999.   DAT  UNKNOWN   25
+     0.50   57.20  '62164     '  999.   DAT  PRIV      15
+     1.90   51.10  '62304     '  14.0   DAT  UKMO      25
+     1.70   60.60  '63055     '  999.   DAT  UNKNOWN   25
+     1.60   59.50  '63056     '  999.   DAT  UNKNOWN   25
+     1.50   59.20  '63057     '  999.   DAT  UNKNOWN  360
+     1.10   61.20  '63103     '  999.   DAT  UNKNOWN   15
+     1.70   60.80  '63108     '  999.   DAT  UNKNOWN   15
+     1.50   59.50  '63110     '  999.   DAT  PRIV      15
+     1.50   59.50  '63111     '  10.0   XDT  PRIV       0
+     1.00   61.10  '63112     '  999.   DAT  PRIV     360
+     1.70   61.00  '63113     '  999.   DAT  PRIV     100
+     1.30   61.60  '63115     '  999.   DAT  PRIV      25
+$
+     2.30   61.20  'LF3J      '  999.   DAT  UNKNOWN   25
+     3.70   60.60  'LF4B      '  999.   DAT  UNKNOWN  360
+     2.20   59.60  'LF4H      '  999.   DAT  UNKNOWN   25
+     1.90   58.40  'LF4C      '  999.   DAT  UNKNOWN   25
+     3.20   56.50  'LF5U      '  999.   DAT  UNKNOWN   60
+$
+     6.33   55.00  'BSH01     '  999.   DAT  UNKNOWN   60
+     7.89   54.16  'BSH02     '  999.   DAT  UNKNOWN   60
+     8.12   54.00  'BSH03     '  999.   DAT  UNKNOWN   60
+     6.58   54.00  'BSH04     '  999.   DAT  UNKNOWN   60
+     8.22   54.92  'BSH05     '  999.   DAT  UNKNOWN   60
+$    13.87   54.88  'BSH54     '  999.   DAT  UNKNOWN   60
+$    12.70   54.70  'BSH71     '  999.   DAT  UNKNOWN   60
+$
+$ Dutch Stations
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+     3.28   51.99  'EURO      '  999.   DAT  MVEW      60
+     3.22   53.22  'K13       '  999.   DAT  MVEW      25
+$
+$ Barents Sea
+$
+    21.10   71.60  '3FYT      '  999.   DAT  UNKNOWN  360
+    15.50   73.50  'LFB1      '  999.   DAT  OCNOR    360
+    30.00   74.00  'LFB2      '  999.   DAT  OCNOR    360
+$
+$ Brazil
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -34.567  -8.15  '31052     '  999.   DAT  PNBOIA   180
+   -43.088 -23.031 '31260     '  999.   DAT  PNBOIA   180
+   -47.367 -28.5   '31374     '  999.   DAT  PNBOIA   180
+   -44.933 -25.283 '31051     '  999.   DAT  PNBOIA   180
+   -51.353 -32.595 '31053     '  999.   DAT  PNBOIA   180
+   -48.13  -27.70  '31201     '  999.   DAT  SCRIPPS  180
+   -48.75  -32.00  'RIO_GRANDE'  999.   VBY  NCEP     360
+   -46.25  -28.00  'FLORIPA   '  999.   VBY  NCEP     360
+   -43.75  -25.00  'SANTOS    '  999.   VBY  NCEP     360
+   -38.75  -21.00  'CAMPOS    '  999.   VBY  NCEP     360
+   -42.187 -22.994 'SIODOC    '  999.   VBY  NCEP     360
+   -44.270 -23.42  'ILHAGRANDE'  999.   VBY  NCEP     360
+   -43.46  -23.16  'RECREIO   '  999.   VBY  NCEP     360
+   -43.12  -23.11  'CAGARRAS  '  999.   VBY  NCEP     360
+   -36.25  -13.00  'SALVADOR  '  999.   VBY  NCEP     360
+   -32.50   -8.00  'RECIFE    '  999.   VBY  NCEP     360
+   -36.25   -3.00  'FORTALEZA '  999.   VBY  NCEP     360
+   -47.50    3.00  'AMAZON    '  999.   VBY  NCEP     360
+   -30.00    1.00  'PETER_PAUL'  999.   VBY  NCEP     360
+$
+$ Peru/Chile Basin
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -85.38  -19.62  '32012'       999.   DAT  WHOI     360
+$
+$ South Africa
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+    22.17  -34.97  'AGULHAS_FA'  10.0   DAT  PRIV     360
+$
+$ Australia
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+$  141.75  -12.68  '52121     '  999.   DAT  UNKNOWN   50
+$  150.34  -35.71  '55014     '  999.   DAT  UNKNOWN   50
+$  153.73  -28.69  '55017     '  999.   DAT  UNKNOWN   10
+$  153.27  -30.35  '55018     '  999.   DAT  UNKNOWN   10
+$  152.86  -31.83  '55019     '  999.   DAT  UNKNOWN   50
+   150.18  -37.29  '55020     '  999.   DAT  UNKNOWN   50
+$  151.03  -34.48  '55022     '  999.   DAT  UNKNOWN   50
+$  151.42  -33.77  '55024     '  999.   DAT  UNKNOWN   50
+$  151.32  -33.90  '55025     '  999.   DAT  UNKNOWN   10
+$  145.01  -42.08  '55026     '  999.   DAT  UNKNOWN   50
+$  145.71  -16.73  '55028     '  999.   DAT  UNKNOWN   50
+$  147.06  -19.16  '55029     '  999.   DAT  UNKNOWN   50
+$  149.55  -21.04  '55031     '  999.   DAT  UNKNOWN   50
+$  149.31  -21.27  '55032     '  999.   DAT  UNKNOWN   15
+   151.07  -23.31  '55033     '  999.   DAT  UNKNOWN   50
+$  153.20  -27.25  '55034     '  999.   DAT  UNKNOWN   10
+   153.63  -27.49  '55035     '  999.   DAT  UNKNOWN   50
+$$  153.44  -27.96  '55036     '  999.   DAT  UNKNOWN   10
+$  153.58  -28.18  '55037     '  999.   DAT  UNKNOWN   10
+   148.19  -38.60  '55039     '  999.   DAT  UNKNOWN   50
+$  136.62  -36.07  '55040     '  999.   DAT  UNKNOWN   50
+   116.14  -19.59  '56002     '  999.   DAT  UNKNOWN  120
+$  114.91  -30.29  '56004     '  999.   DAT  UNKNOWN   50
+   115.40  -32.11  '56005     '  999.   DAT  UNKNOWN   50
+   114.78  -33.36  '56006     '  999.   DAT  UNKNOWN  120
+   114.94  -21.41  '56007     '  999.   DAT  UNKNOWN   50
+   121.90  -34.00  '56010     '  999.   DAT  UNKNOWN   50
+$  117.72  -35.20  '56011     '  999.   DAT  UNKNOWN   50
+   114.10  -21.70  '56012     '  999.   DAT  UNKNOWN   50
+$  115.69  -31.98  '56008     '  999.   DAT  UNKNOWN   25
+   136.20  -36.10  'CADUCOU   '  999.   VBY  UNKNOWN  120
+   139.00  -38.00  'SWROBE    '  999.   VBY  UNKNOWN  120
+   142.45  -39.20  'WBAST1    '  999.   VBY  UNKNOWN  120
+   141.50  -40.00  'WBAST2    '  999.   VBY  UNKNOWN  120
+   151.00  -40.00  'EBAST     '  999.   VBY  UNKNOWN  120
+   146.50  -40.50  'CBAST     '  999.   VBY  UNKNOWN  120
+   144.60  -42.30  'CSORRELL  '  999.   VBY  UNKNOWN  120
+   144.50  -40.10  'SEKING    '  999.   VBY  UNKNOWN  120
+   143.80  -39.20  'NKING     '  999.   VBY  UNKNOWN  120
+   144.85  -38.60  'PNEPEAN   '  999.   VBY  UNKNOWN  120
+   147.40  -39.20  'EHOGAN    '  999.   VBY  UNKNOWN  120
+   147.00  -44.00  'STHSEC    '  999.   VBY  UNKNOWN  120
+   149.50  -41.50  'EBICHENO  '  999.   VBY  UNKNOWN  120
+   133.50  -33.50  'WCAPYORK  '  999.   VBY  UNKNOWN  120
+   114.617 -19.785 'JANSZ     '  999.   VBY  UNKNOWN  120
+$
+$ India
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+    72.49   17.02  '23092     '  999.   DAT  UNKNOWN   20
+    73.75   15.40  '23093     '  999.   DAT  UNKNOWN  120
+    74.50   12.94  '23094     '  999.   DAT  UNKNOWN  120
+    80.39   13.19  '23096     '  999.   DAT  UNKNOWN  120
+    69.24   15.47  '23097     '  999.   DAT  UNKNOWN  360
+    72.51   10.65  '23098     '  999.   DAT  UNKNOWN  360
+    90.74   12.14  '23099     '  999.   DAT  UNKNOWN  360
+    87.56   18.35  '23100     '  999.   DAT  UNKNOWN  120
+    83.27   13.97  '23101     '  999.   DAT  UNKNOWN  360
+    85.00   12.60  '23167     '  999.   DAT  UNKNOWN  360
+    87.50   15.00  '23168     '  999.   DAT  UNKNOWN  360
+    90.14   18.13  '23169     '  999.   DAT  UNKNOWN  360
+    72.66    8.33  '23170     '  999.   DAT  UNKNOWN  360
+    70.00   11.02  '23171     '  999.   DAT  UNKNOWN  360
+    72.00   12.50  '23172     '  999.   DAT  UNKNOWN  360
+    78.57    8.21  '23173     '  999.   DAT  UNKNOWN  120
+    81.53   11.57  '23174     '  999.   DAT  UNKNOWN  360
+    91.66   10.52  '23451     '  999.   DAT  UNKNOWN  120
+    89.04   10.97  '23455     '  999.   DAT  UNKNOWN  120
+    86.98    9.99  '23456     '  999.   DAT  UNKNOWN  120
+    70.10    5.16  '23491     '  999.   DAT  UNKNOWN  120
+    68.08   13.89  '23492     '  999.   DAT  UNKNOWN  120
+    66.98   11.12  '23493     '  999.   DAT  UNKNOWN  120
+    75.00    6.46  '23494     '  999.   DAT  UNKNOWN  120
+    68.97    7.13  '23495     '  999.   DAT  UNKNOWN  120
+$
+$ Red Sea
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+$    38.50   23.16  '23020     '  999.   DAT  UNKNOWN  120
+$
+$ Spain
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+    -3.03   43.63  '62024     '  999.   DAT  PDES      25
+$    -6.17   43.73  '62025     '  999.   DAT  PDES      25
+    -7.62   44.07  '62082     '  999.   DAT  PDES      25
+$    -9.22   43.48  '62083     '  999.   DAT  PDES      25
+    -9.40   42.12  '62084     '  999.   DAT  PDES      25
+    -6.97   36.48  '62085     '  999.   DAT  PDES      25
+$
+$ Mediteranean Sea
+$
+$     3.65   41.92  '61196     '  999.   DAT  PDES      25
+$     4.42   39.72  '61197     '  999.   DAT  PDES      25
+$    -2.33   36.57  '61198     '  999.   DAT  PDES      25
+$    -5.03   36.23  '61199     '  999.   DAT  PDES      25
+$     1.47   40.77  '61280     '  999.   DAT  PDES      25
+$     0.21   39.52  '61281     '  999.   DAT  PDES      25
+$    -0.32   37.65  '61417     '  999.   DAT  PDES      25
+$     2.10   39.55  '61430     '  999.   DAT  PDES      25
+$     7.80   43.40  '61001     '  999.   DAT  METFR     25
+$     4.70   42.10  '61002     '  999.   DAT  METFR     25
+$
+$ Canary Islands
+$
+   -15.82   28.18  '13130     '  999.   DAT  PDES      25
+   -16.58   28.00  '13131     '  999.   DAT  PDES      25
+$
+$ Africa
+$
+$    57.70  -20.45  'MAUR01    '  999.   DAT  WMO      360
+$    57.75  -20.10  'MAUR02    '  999.   DAT  WMO      360
+$    55.00  -25.00  'V14003    '  999.   VBY  WMO      360
+$    60.00  -25.00  'V14004    '  999.   VBY  WMO      360
+$    57.00  -20.00  'V14005    '  999.   VBY  WMO      360
+$    60.00  -20.00  'V14006    '  999.   VBY  WMO      360
+$    63.00  -20.00  'V14007    '  999.   VBY  WMO      360
+$    64.00  -19.00  'V14008    '  999.   VBY  WMO      360
+$    58.00  -18.00  'V14009    '  999.   VBY  WMO      360
+$    60.00  -16.00  'V14010    '  999.   VBY  WMO      360
+$    56.00  -10.00  'V14011    '  999.   VBY  WMO      360
+$    57.00  -11.00  'V14012    '  999.   VBY  WMO      360
+$    70.00  -25.00  'V14013    '  999.   VBY  WMO      360
+$    80.00  -25.00  'V14014    '  999.   VBY  WMO      360
+$    90.00  -25.00  'V53015    '  999.   VBY  WMO      360
+$    70.00  -15.00  'V14016    '  999.   VBY  WMO      360
+$    80.00  -15.00  'V14017    '  999.   VBY  WMO      360
+$    90.00  -15.00  'V53018    '  999.   VBY  WMO      360
+$    65.00   -5.00  'V23019    '  999.   VBY  WMO      360
+$    75.00   -5.00  'V23020    '  999.   VBY  WMO      360
+$    85.00   -5.00  'V23021    '  999.   VBY  WMO      360
+$    95.00   -5.00  'V23022    '  999.   VBY  WMO      360
+$    55.00   -5.00  'V14023    '  999.   VBY  WMO      360
+$    10.929 -17.328 'V14039    '  999.   VBY  WMO      360
+$    10.953 -18.097 'V14040    '  999.   VBY  WMO      360
+$    11.681 -19.001 'V14041    '  999.   VBY  WMO      360
+$    12.250 -20.069 'V14042    '  999.   VBY  WMO      360
+$    12.653 -20.967 'V14043    '  999.   VBY  WMO      360
+$    13.223 -21.930 'V14044    '  999.   VBY  WMO      360
+$    13.418 -22.624 'V14045    '  999.   VBY  WMO      360
+$    13.584 -23.613 'V14046    '  999.   VBY  WMO      360
+$    13.659 -24.375 'V14047    '  999.   VBY  WMO      360
+$    13.951 -25.245 'V14048    '  999.   VBY  WMO      360
+$    14.032 -26.084 'V14049    '  999.   VBY  WMO      360
+$    14.191 -26.728 'V14050    '  999.   VBY  WMO      360
+$    14.536 -27.593 'V14051    '  999.   VBY  WMO      360
+$    14.968 -28.341 'V14052    '  999.   VBY  WMO      360
+$    15.676 -29.085 'V14053    '  999.   VBY  WMO      360
+$    39.750  -5.000 'V14054    '  999.   VBY  WMO      360
+$    39.750  -5.583 'V14055    '  999.   VBY  WMO      360
+$    39.750  -6.217 'V14056    '  999.   VBY  WMO      360
+$    39.800  -6.750 'V14057    '  999.   VBY  WMO      360
+$    39.917  -7.083 'V14058    '  999.   VBY  WMO      360
+$    39.750  -7.300 'V14059    '  999.   VBY  WMO      360
+$    39.750  -8.167 'V14060    '  999.   VBY  WMO      360
+$    40.250  -8.833 'V14061    '  999.   VBY  WMO      360
+$    40.250  -9.167 'V14062    '  999.   VBY  WMO      360
+$    40.250  -9.917 'V14063    '  999.   VBY  WMO      360
+$    40.583 -10.333 'V14064    '  999.   VBY  WMO      360
+$    42.000 -11.000 'V14065    '  999.   VBY  WMO      360
+$    42.000 -12.000 'V14066    '  999.   VBY  WMO      360
+$    42.000 -13.000 'V14067    '  999.   VBY  WMO      360
+$    42.000 -14.000 'V14068    '  999.   VBY  WMO      360
+$    42.000 -15.000 'V14069    '  999.   VBY  WMO      360
+$    40.250 -17.000 'V14070    '  999.   VBY  WMO      360
+$    39.000 -17.833 'V14071    '  999.   VBY  WMO      360
+$    38.250 -18.000 'V14072    '  999.   VBY  WMO      360
+$    37.250 -19.000 'V14073    '  999.   VBY  WMO      360
+$    35.500 -20.000 'V14074    '  999.   VBY  WMO      360
+$    36.000 -21.000 'V14075    '  999.   VBY  WMO      360
+$    35.567 -21.917 'V14076    '  999.   VBY  WMO      360
+$    35.583 -22.000 'V14077    '  999.   VBY  WMO      360
+$    42.833 -22.000 'V14078    '  999.   VBY  WMO      360
+$    36.000 -23.000 'V14079    '  999.   VBY  WMO      360
+$    36.833 -24.000 'V14080    '  999.   VBY  WMO      360
+$    36.000 -25.000 'V14081    '  999.   VBY  WMO      360
+$    35.000 -25.500 'V14082    '  999.   VBY  WMO      360
+$    34.000 -26.000 'V14083    '  999.   VBY  WMO      360
+$    34.000 -27.000 'V14084    '  999.   VBY  WMO      360
+$
+$ TPC and OPC
+$
+$   LON     LAT     NAME          AH   TYPE  SOURCE  SCALE
+$ ---------------------------------------------------------
+   -85.00  -15.00  'TPC01     '  999.   VBY  NCEP     360
+  -110.00  -15.00  'TPC02     '  999.   VBY  NCEP     360
+  -135.00  -15.00  'TPC03     '  999.   VBY  NCEP     360
+   -93.75    0.00  'TPC04     '  999.   VBY  NCEP     360
+$
+   -55.00   15.00  'TPC20     '  999.   VBY  NCEP     360
+   -63.00   15.00  'TPC21     '  999.   VBY  NCEP     360
+   -77.00   12.00  'TPC22     '  999.   VBY  NCEP     360
+   -80.00   15.00  'TPC23     '  999.   VBY  NCEP     360
+   -76.00   22.00  'TPC24     '  999.   VBY  NCEP     360
+   -80.00   24.00  'TPC25     '  999.   VBY  NCEP     360
+   -86.00   23.00  'TPC26     '  999.   VBY  NCEP     360
+$
+  -118.00   30.00  'TPC50     '  999.   VBY  NCEP     360
+  -135.00   20.00  'TPC51     '  999.   VBY  NCEP     360
+  -117.00   20.00  'TPC52     '  999.   VBY  NCEP     360
+  -120.00    6.00  'TPC53     '  999.   VBY  NCEP     360
+   -95.00   15.00  'TPC54     '  999.   VBY  NCEP     360
+   -88.00    9.00  'TPC55     '  999.   VBY  NCEP     360
+   -80.00    6.00  'TPC56     '  999.   VBY  NCEP     360
+$
+  -130.50   48.10  'OPCP01    '  999.   VBY  NCEP      45
+  -126.60   48.10  'OPCP02    '  999.   VBY  NCEP      45
+  -129.70   45.30  'OPCP03    '  999.   VBY  NCEP      45
+  -125.60   45.30  'OPCP04    '  999.   VBY  NCEP      45
+  -129.90   41.75  'OPCP05    '  999.   VBY  NCEP      45
+  -125.80   41.90  'OPCP06    '  999.   VBY  NCEP      45
+  -129.00   38.50  'OPCP07    '  999.   VBY  NCEP      45
+  -125.50   39.20  'OPCP08    '  999.   VBY  NCEP      45
+  -125.40   36.40  'OPCP09    '  999.   VBY  NCEP      45
+  -125.00   33.30  'OPCP10    '  999.   VBY  NCEP      45
+  -122.30   34.60  'OPCP11    '  999.   VBY  NCEP      45
+  -121.50   30.90  'OPCP12    '  999.   VBY  NCEP      45
+  -117.00   29.60  'OPCP13    '  999.   VBY  NCEP      45
+$
+   -67.70   42.35  'OPCA01    '  999.   VBY  NCEP      45
+   -72.00   39.30  'OPCA02    '  999.   VBY  NCEP      45
+   -65.70   39.30  'OPCA03    '  999.   VBY  NCEP      45
+   -70.10   37.30  'OPCA04    '  999.   VBY  NCEP      45
+   -74.60   36.30  'OPCA05    '  999.   VBY  NCEP      45
+   -73.80   35.60  'OPCA06    '  999.   VBY  NCEP      45
+   -70.80   34.90  'OPCA07    '  999.   VBY  NCEP      45
+   -76.00   33.80  'OPCA08    '  999.   VBY  NCEP      45
+   -72.30   32.80  'OPCA09    '  999.   VBY  NCEP      45
+$
+$ WAM AFOS locations
+$
+$  -72.5    35.0   'ZNT41     '  999.   VBY  NCEP       0
+$  -70.0    37.5   'ZNT42     '  999.   VBY  NCEP       0
+$  -67.5    40.0   'ZNT43     '  999.   VBY  NCEP       0
+$  -85.0    25.0   'ZNT45     '  999.   VBY  NCEP       0
+$ -125.0    47.5   'ZPZ41     '  999.   VBY  NCEP       0
+$ -125.0    45.0   'ZPZ42     '  999.   VBY  NCEP       0
+$ -130.0    42.5   'ZPZ43     '  999.   VBY  NCEP       0
+$ -122.5    35.0   'ZPZ44     '  999.   VBY  NCEP       0
+$ -120.0    32.5   'ZPZ45     '  999.   VBY  NCEP       0
+$ -122.5    27.5   'ZPZ46     '  999.   VBY  NCEP       0
+$
+$ ---------------------------------------------------------------
+$ End of list
+$
+$ ---------------------------------------------------------------
+$
+     0.00    0.00  'STOPSTRING'  999.   XXX  NCEP       0


### PR DESCRIPTION
## Description of changes
We are switching to use ww3_shel.nml which requires a ww3_point.list file.  This file corresponds to the points currently in ww3_shel.inp_tmpl so no point output will change. 

## Issues addressed (optional)
n/a

## Dependencies (optional)
n/a

## Contributors (optional)
@BinLiu-NOAA  @LinZhu-NOAA @MariaAristizabal-NOAA  are all helping make sure WW3 is working for downstream of GFSv17. 

## Tests conducted
Not yet... 

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

- [ ] Jet
- [ ] Hera
- [ ] Orion
- [ ] WCOSS2
