### PR TITLE
Sync latest hafs.v2.2 changes updating config options for HFSB EPAC/CPAC basins 

### DIFF
--- a/parm/hfsb_CP.conf
+++ b/parm/hfsb_CP.conf
@@ -17,6 +17,12 @@ ccpp_suite_regional=FV3_HAFS_v2_gfdlmp_coupled
 ccpp_suite_glob=FV3_HAFS_v2_gfdlmp_coupled
 ccpp_suite_nest=FV3_HAFS_v2_gfdlmp_coupled
 
+k_split=3,4
+n_split=4,8
+lim_fac=3.0,3.0
+fhswr=1800.
+fhlwr=1800.
+
 # GFDL MP related options
 imp_physics=11
 dnats=1

--- a/parm/hfsb_EP.conf
+++ b/parm/hfsb_EP.conf
@@ -17,6 +17,12 @@ ccpp_suite_regional=FV3_HAFS_v2_gfdlmp_coupled
 ccpp_suite_glob=FV3_HAFS_v2_gfdlmp_coupled
 ccpp_suite_nest=FV3_HAFS_v2_gfdlmp_coupled
 
+k_split=3,4
+n_split=4,8
+lim_fac=3.0,3.0
+fhswr=1800.
+fhlwr=1800.
+
 # GFDL MP related options
 imp_physics=11
 dnats=1

--- a/parm/hfsb_other_basins.conf
+++ b/parm/hfsb_other_basins.conf
@@ -33,6 +33,12 @@ ccpp_suite_regional=FV3_HAFS_v2_gfdlmp_coupled
 ccpp_suite_glob=FV3_HAFS_v2_gfdlmp_coupled
 ccpp_suite_nest=FV3_HAFS_v2_gfdlmp_coupled
 
+k_split=3,4
+n_split=4,8
+lim_fac=3.0,3.0
+fhswr=1800.
+fhlwr=1800.
+
 # GFDL MP related options
 imp_physics=11
 dnats=1


### PR DESCRIPTION
## Description of changes

Sync over the latest operational hafs.v2.2 changes updating config options for HFSB EPAC/CPAC basins to improve forecast job numerical stability.

## Issues addressed (optional)
If this PR addresses one or more issues, please provide link(s) to the issue(s) here.
- fixes hafs-community/HAFS/issues/<issue_number>

## Tests conducted
What testing has been conducted on the PR thus far? Describe the nature of any scientific or technical tests, including relevant details about the configuration(s) (e.g., cold versus warm start, number of cycles, forecast length, whether data assimilation was performed, etc). What platform(s) were used for testing?

Tested with HAFSv2.2 canned test cases as well in NCO parallel.

## Application-level regression test status
Running the HAFS application-level regression tests is currently performed by code reviewers after the developer creates the initial PR. As regression tests are conducted, the testers should use the checklist below to indicate **successful** regression tests. You may add other tests as needed. If a test fails, do not check the box. Instead, describe the failure in the PR comments, noting the platform where the test failed.

Since this is just a minor config option change/update, we can skip the full application regression tests.
